### PR TITLE
Added overload for appSettings configuration to resolve #425

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -17,7 +17,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Serilog.Configuration;
 using Serilog.Core;
-using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Sinks.Elasticsearch;
 
@@ -75,17 +74,8 @@ namespace Serilog
             string indexFormat = null,
             string templateName = null)
         {
-            ElasticsearchSinkOptions options;
-            try
-            {
-                IEnumerable<Uri> nodes = nodeUris.Split(',').Select(uriString => new Uri(uriString));
-                options = new ElasticsearchSinkOptions(nodes);
-            }
-            catch (Exception ex)
-            {
-                SelfLog.WriteLine("Exception while parsing node URIs from {0}: {1}", nodeUris, ex);
-                options = new ElasticsearchSinkOptions(new[] { new Uri(DefaultNodeUri) });
-            }
+            IEnumerable<Uri> nodes = nodeUris.Split(',').Select(uriString => new Uri(uriString));
+            var options = new ElasticsearchSinkOptions(nodes);
 
             if (!string.IsNullOrWhiteSpace(indexFormat))
             {

--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -56,5 +56,35 @@ namespace Serilog
 
             return loggerSinkConfiguration.Sink(sink, options.MinimumLogEventLevel ?? LevelAlias.Minimum);
         }
+
+        /// <summary>
+        /// Overload to allow basic configuration through AppSettings.
+        /// </summary>
+        /// <param name="loggerSinkConfiguration">Options for the sink.</param>
+        /// <param name="uri">A URI for the Elasticsearch instance</param>
+        /// <param name="indexFormat"><see cref="ElasticsearchSinkOptions.IndexFormat"/></param>
+        /// <param name="templateName"><see cref="ElasticsearchSinkOptions.TemplateName"/></param>
+        /// <returns>LoggerConfiguration object</returns>
+        public static LoggerConfiguration Elasticsearch(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            string uri,
+            string indexFormat = null,
+            string templateName = null)
+        {
+            var options = new ElasticsearchSinkOptions(new[] { new Uri(uri) });
+
+            if (!string.IsNullOrWhiteSpace(indexFormat))
+            {
+                options.IndexFormat = indexFormat;
+            }
+
+            if (!string.IsNullOrWhiteSpace(templateName))
+            {
+                options.AutoRegisterTemplate = true;
+                options.TemplateName = templateName;
+            }
+
+            return Elasticsearch(loggerSinkConfiguration, options);
+        }
     }
 }


### PR DESCRIPTION
Added a simple overload with the parameters @mivano suggested. I made the index format and template registration optional to remain in the spirit of bare minimum configuration (server address only) required.

If this gets merged in the "Breaking changes for version 2" section in the readme should probably be updated to reflect that basic appSettings configuration is possible.