### PR TITLE
delay auto-register-template-if-necessary call to the first timer tick

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/DurableElasticSearchSink.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/DurableElasticSearchSink.cs
@@ -26,7 +26,7 @@ namespace Serilog.Sinks.Elasticsearch
 
         readonly RollingFileSink _sink;
         readonly ElasticsearchLogShipper _shipper;
-        private readonly ElasticsearchSinkState _state;
+        readonly ElasticsearchSinkState _state;
 
         public DurableElasticsearchSink(ElasticsearchSinkOptions options)
         {

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchLogShipper.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchLogShipper.cs
@@ -37,6 +37,8 @@ namespace Serilog.Sinks.Elasticsearch
         readonly string _logFolder;
         readonly string _candidateSearchPath;
 
+        bool _didRegisterTemplateIfNeeded;
+
         internal ElasticsearchLogShipper(ElasticsearchSinkState state)
         {
             _state = state;
@@ -111,6 +113,13 @@ namespace Serilog.Sinks.Elasticsearch
         {
             try
             {
+                // on the very first timer tick, we make the auto-register-if-necessary call
+                if (!_didRegisterTemplateIfNeeded)
+                {
+                    _state.RegisterTemplateIfNeeded();
+                    _didRegisterTemplateIfNeeded = true;
+                }
+
                 var count = 0;
 
                 do

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
@@ -37,6 +37,7 @@ namespace Serilog.Sinks.Elasticsearch
             : base(options.BatchPostingLimit, options.Period)
         {
 	        _state = ElasticsearchSinkState.Create(options);
+            _state.RegisterTemplateIfNeeded();
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
@@ -29,11 +29,12 @@ namespace Serilog.Sinks.Elasticsearch
     {
         public static ElasticsearchSinkState Create(ElasticsearchSinkOptions options)
         {
-            if (options == null) throw new ArgumentNullException("options");
-            var state = new ElasticsearchSinkState(options);
-            if (state.Options.AutoRegisterTemplate)
-                state.RegisterTemplateIfNeeded();
-            return state;
+            if (options == null)
+            {
+                throw new ArgumentNullException("options");
+            }
+            
+            return new ElasticsearchSinkState(options);
         }
 
         private readonly ElasticsearchSinkOptions _options;
@@ -94,7 +95,7 @@ namespace Serilog.Sinks.Elasticsearch
                inlineFields: options.InlineFields
            );
 
-            this._registerTemplateOnStartup = options.AutoRegisterTemplate;
+            _registerTemplateOnStartup = options.AutoRegisterTemplate;
         }
 
 
@@ -117,10 +118,10 @@ namespace Serilog.Sinks.Elasticsearch
             if (!this._registerTemplateOnStartup) return;
 
             try
-            { 
+            {
                 var templateExistsResponse = this._client.IndicesExistsTemplateForAll<VoidResponse>(this._templateName);
                 if (templateExistsResponse.HttpStatusCode == 200) return;
-            
+
                 var result = this._client.IndicesPutTemplateForAll<VoidResponse>(this._templateName, new
                 {
                     template = this._templateMatchString,


### PR DESCRIPTION
when using the durable sink, because we should not do this synchronously on the initializing thread when logging is initialized