### PR TITLE
Comment unused GetValue on WatsonBuckets - Fix Mono SerializationExce…

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchJsonFormatter.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchJsonFormatter.cs
@@ -147,7 +147,7 @@ namespace Serilog.Sinks.Elasticsearch
             var hresult = si.GetInt32("HResult");
             var source = si.GetString("Source");
             var className = si.GetString("ClassName");
-            var watsonBuckets = si.GetValue("WatsonBuckets", typeof(byte[])) as byte[];
+            //var watsonBuckets = si.GetValue("WatsonBuckets", typeof(byte[])) as byte[];
 
             //TODO Loop over ISerializable data
 


### PR DESCRIPTION
The call to get WatsonBuckets throw a SerializationException on Mono (not found).
So the event is never send to EL.