### PR TITLE
Do not depend on specific version of serilog

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -51,9 +51,11 @@
       <HintPath>..\..\packages\Elasticsearch.Net.1.1.2\lib\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Serilog">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Serilog.1.4.196\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.FullNetFx">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Serilog.1.4.196\lib\net45\Serilog.FullNetFx.dll</HintPath>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
Without this change this sink does not work for serilog 1.5.* w/o a redirect