### PR TITLE
Added a way to derive from ElasticsearchSink class so that customized…

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.Symbols.nuspec
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.Symbols.nuspec
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>Serilog.Sinks.Elasticsearch</id>
+    <version>2.0.60.2</version>
+    <authors>Michiel van Oudheusden, Martijn Laarman, Mogens Heller Grabe</authors>
+    <description>The perfect way for .NET apps to write structured log events to Elasticsearch.</description>
+    <language>en-US</language>
+    <projectUrl>http://serilog.net</projectUrl>
+    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
+    <tags>serilog logging elasticsearch</tags>
+    <dependencies>
+      <dependency id="Serilog" version="[1.4.204,2)" />
+      <dependency id="Elasticsearch.Net" version="1.1.2" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\Serilog.Sinks.Elasticsearch.dll" target="lib\net45" />
+    <file src="bin\Release\Serilog.Sinks.Elasticsearch.pdb" target="lib\net45" />
+    <file src="**\*.cs" target="src" />
+  </files>
+</package>

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -81,6 +81,7 @@
     <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Serilog.Sinks.Elasticsearch.nuspec" />
+    <None Include="Serilog.Sinks.ElasticSearch.Symbols.nuspec" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.5">

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
@@ -21,6 +21,8 @@ using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.Elasticsearch
 {
+    using global::Elasticsearch.Net;
+
     /// <summary>
     /// Writes log events as documents to ElasticSearch.
     /// </summary>
@@ -51,22 +53,32 @@ namespace Serilog.Sinks.Elasticsearch
         /// </remarks>
         protected override void EmitBatch(IEnumerable<LogEvent> events)
         {
+            this.EmitBatchChecked(events);
+        }
+
+        /// <summary>
+        /// Emit a batch of log events, running to completion synchronously.
+        /// </summary>
+        /// <param name="events">The events to emit.</param>
+        /// <returns>Response from Elasticsearch</returns>
+        protected virtual ElasticsearchResponse<DynamicDictionary> EmitBatchChecked(IEnumerable<LogEvent> events)
+        {
             // ReSharper disable PossibleMultipleEnumeration
             if (events == null || !events.Any())
-                return;
+                return null;
 
             var payload = new List<string>();
             foreach (var e in events)
             {
                 var indexName = _state.GetIndexForEvent(e, e.Timestamp.ToUniversalTime());
                 var action = new { index = new { _index = indexName, _type = _state.Options.TypeName } };
-	            var actionJson = _state.Serialize(action);
+                var actionJson = _state.Serialize(action);
                 payload.Add(actionJson);
                 var sw = new StringWriter();
                 _state.Formatter.Format(e, sw);
                 payload.Add(sw.ToString());
             }
-            _state.Client.Bulk(payload);
+            return _state.Client.Bulk(payload);
         }
     }
 }


### PR DESCRIPTION
… EmitBatch method would be able to analyse Elasticsearch response and get specific errors in case emit was unsuccessful.

Unfortunately existing call _state.Client.Bulk(payload); does not allow to check Elasticsearch response in any way. I have split EmitBatch to two methods:
EmitBatchChecked does what EmitBatch did, but returns ES response.
Existing EmitBatch just calls EmitBatchChecked and drops return value.

Class which overrides ElasticsearchSink may override EmitBatch to call base class EmitBatchChecked, but then do necessary ES response analysis.

Konstantin