### PR TITLE
fix issue with ElasticSearch not supporting '.' in fieldnames

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -49,9 +49,11 @@
     <Reference Include="Elasticsearch.Net">
       <HintPath>..\..\packages\Elasticsearch.Net.1.7.1\lib\net45\Elasticsearch.Net.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Serilog">
       <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.FullNetFx">
+      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -49,11 +49,9 @@
     <Reference Include="Elasticsearch.Net">
       <HintPath>..\..\packages\Elasticsearch.Net.1.7.1\lib\net45\Elasticsearch.Net.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog">
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog.FullNetFx">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchJsonFormatter.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchJsonFormatter.cs
@@ -88,6 +88,15 @@ namespace Serilog.Sinks.Elasticsearch
                 output.Write("}");
         }
 
+        /// <summary>
+        /// Escape the name of the Property before calling ElasticSearch
+        /// </summary>
+        protected override void WriteDictionary(IDictionary<ScalarValue, LogEventPropertyValue> elements, TextWriter output) {
+            var escaped = elements.ToDictionary(e => DotEscapeFieldName(e.Key), e => e.Value);
+
+            base.WriteDictionary(escaped, output);
+        }
+
 #else
         /// <summary>
         /// Writes out individual renderings of attached properties
@@ -115,6 +124,16 @@ namespace Serilog.Sinks.Elasticsearch
                 output.Write("}");
         }
 
+        /// <summary>
+        /// Escape the name of the Property before calling ElasticSearch
+        /// </summary>
+        protected override void WriteDictionary(IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> elements, TextWriter output)
+        {
+            var escaped = elements.ToDictionary(e => DotEscapeFieldName(e.Key), e => e.Value);
+
+            base.WriteDictionary(escaped, output);
+        }
+
 #endif
         /// <summary>
         /// Escape the name of the Property before calling ElasticSearch
@@ -124,16 +143,6 @@ namespace Serilog.Sinks.Elasticsearch
             name = DotEscapeFieldName(name);
 
             base.WriteJsonProperty(name, value, ref precedingDelimiter, output);
-        }
-
-        /// <summary>
-        /// Escape the name of the Property before calling ElasticSearch
-        /// </summary>
-        protected override void WriteDictionary(IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> elements, TextWriter output)
-        {
-            var escaped = elements.ToDictionary(e => DotEscapeFieldName(e.Key), e => e.Value);
-
-            base.WriteDictionary(escaped, output);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchJsonFormatter.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchJsonFormatter.cs
@@ -116,7 +116,48 @@ namespace Serilog.Sinks.Elasticsearch
         }
 
 #endif
+        /// <summary>
+        /// Escape the name of the Property before calling ElasticSearch
+        /// </summary>
+        protected override void WriteJsonProperty(string name, object value, ref string precedingDelimiter, TextWriter output)
+        {
+            name = DotEscapeFieldName(name);
 
+            base.WriteJsonProperty(name, value, ref precedingDelimiter, output);
+        }
+
+        /// <summary>
+        /// Escape the name of the Property before calling ElasticSearch
+        /// </summary>
+        protected override void WriteDictionary(IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> elements, TextWriter output)
+        {
+            var escaped = elements.ToDictionary(e => DotEscapeFieldName(e.Key), e => e.Value);
+
+            base.WriteDictionary(escaped, output);
+        }
+
+        /// <summary>
+        /// Escapes Dots in Strings and does nothing to objects
+        /// </summary>
+        protected virtual ScalarValue DotEscapeFieldName(ScalarValue value)
+        {
+            if (value.Value is string)
+            {
+                return new ScalarValue(DotEscapeFieldName((string)value.Value));
+            }
+
+            return value;
+        }
+        /// <summary>
+        /// Dots are not allowed in Field Names, replaces '.' with '/'
+        /// https://github.com/elastic/elasticsearch/issues/14594
+        /// </summary>
+        protected virtual string DotEscapeFieldName(string value)
+        {
+            if (value == null) return null;
+
+            return value.Replace('.', '/');
+        }
         /// <summary>
         /// Writes out the attached exception
         /// </summary>


### PR DESCRIPTION
Dots are not allowed in Field Names, replaces '.' with '/' https://github.com/elastic/elasticsearch/issues/14594