### PR TITLE
Replaced DynamicResponse with BulkResponse

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -50,6 +50,14 @@
       <HintPath>..\..\packages\Elasticsearch.Net.2.0.2\lib\net45\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NEST.2.0.2\lib\net45\Nest.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Serilog">
       <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
     </Reference>

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Nest;
 using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
 
@@ -61,7 +62,7 @@ namespace Serilog.Sinks.Elasticsearch
         /// </summary>
         /// <param name="events">The events to emit.</param>
         /// <returns>Response from Elasticsearch</returns>
-        protected virtual ElasticsearchResponse<DynamicResponse> EmitBatchChecked(IEnumerable<LogEvent> events)
+        protected virtual ElasticsearchResponse<BulkResponse> EmitBatchChecked(IEnumerable<LogEvent> events)
         {
             // ReSharper disable PossibleMultipleEnumeration
             if (events == null || !events.Any())
@@ -78,7 +79,7 @@ namespace Serilog.Sinks.Elasticsearch
                 _state.Formatter.Format(e, sw);
                 payload.Add(sw.ToString());
             }
-            return _state.Client.Bulk<DynamicResponse>(payload);
+            return _state.Client.Bulk<BulkResponse>(payload);
         }
     }
 }

--- a/src/Serilog.Sinks.Elasticsearch/packages.config
+++ b/src/Serilog.Sinks.Elasticsearch/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Elasticsearch.Net" version="2.0.2" targetFramework="net45" />
+  <package id="NEST" version="2.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="Serilog" version="1.5.14" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is the change which motivated me to update ES sink for NEST 2.0 compatibility. EmitBatchChecked return type is not very generic and hard to handle DynamicResponse, but rather very specific and much less error prone to handle BulkResponse. Result of ES bulk indexing request can be checked for success (and errors may be reported otherwise) much faster and easier than before. 