### PR TITLE
Replaced DynamicResponse with BulkResponse

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch-net40.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch-net40.csproj
@@ -50,6 +50,14 @@
       <HintPath>..\..\packages\Elasticsearch.Net.2.0.2\lib\net45\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NEST.2.0.4\lib\net45\Nest.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Serilog">
       <HintPath>..\..\packages\Serilog.1.5.14\lib\net40\Serilog.dll</HintPath>
     </Reference>

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -47,7 +47,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Elasticsearch.Net.2.0.2\lib\net45\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\..\packages\Elasticsearch.Net.2.0.4\lib\net45\Elasticsearch.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NEST.2.0.4\lib\net45\Nest.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog">

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchLogShipper.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchLogShipper.cs
@@ -21,6 +21,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Elasticsearch.Net;
+using Nest;
 using Serilog.Debugging;
 
 namespace Serilog.Sinks.Elasticsearch
@@ -181,7 +182,7 @@ namespace Serilog.Sinks.Elasticsearch
 
                         if (count > 0)
                         {
-                            var response = _state.Client.Bulk<DynamicResponse>(payload);
+                            var response = _state.Client.Bulk<BulkResponse>(payload);
 
                             if (response.Success)
                             {

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Nest;
 using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
 
@@ -61,7 +61,7 @@ namespace Serilog.Sinks.Elasticsearch
         /// </summary>
         /// <param name="events">The events to emit.</param>
         /// <returns>Response from Elasticsearch</returns>
-        protected virtual ElasticsearchResponse<DynamicResponse> EmitBatchChecked(IEnumerable<LogEvent> events)
+        protected virtual ElasticsearchResponse<BulkResponse> EmitBatchChecked(IEnumerable<LogEvent> events)
         {
             // ReSharper disable PossibleMultipleEnumeration
             if (events == null || !events.Any())
@@ -78,7 +78,7 @@ namespace Serilog.Sinks.Elasticsearch
                 _state.Formatter.Format(e, sw);
                 payload.Add(sw.ToString());
             }
-            return _state.Client.Bulk<DynamicResponse>(payload);
+            return _state.Client.Bulk<BulkResponse>(payload);
         }
     }
 }

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 using Elasticsearch.Net;
+using Nest;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting;
@@ -121,10 +122,10 @@ namespace Serilog.Sinks.Elasticsearch
 
             try
             {
-                var templateExistsResponse = this._client.IndicesExistsTemplateForAll<DynamicResponse>(this._templateName);
+                var templateExistsResponse = this._client.IndicesExistsTemplateForAll<BulkResponse>(this._templateName);
                 if (templateExistsResponse.HttpStatusCode == 200) return;
 
-                var result = this._client.IndicesPutTemplateForAll<DynamicResponse>(this._templateName, new
+                var result = this._client.IndicesPutTemplateForAll<BulkResponse>(this._templateName, new
                 {
                     template = this._templateMatchString,
                     settings = new Dictionary<string, string>

--- a/src/Serilog.Sinks.Elasticsearch/packages.config
+++ b/src/Serilog.Sinks.Elasticsearch/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="2.0.2" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="2.0.4" targetFramework="net45" />
+  <package id="NEST" version="2.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="Serilog" version="1.5.14" targetFramework="net45" />
 </packages>

--- a/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTestsBase.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTestsBase.cs
@@ -37,7 +37,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests
                 Connection = _connection
             };
 
-            A.CallTo(() => _connection.Request<DynamicResponse>(A<RequestData>._))
+            A.CallTo(() => _connection.Request<BulkResponse>(A<RequestData>._))
                 .ReturnsLazily((RequestData requestData) =>
                 {
                     MemoryStream ms = new MemoryStream();
@@ -56,7 +56,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests
                             _seenHttpHeads.Add(_templateExistsReturnCode);
                             break;
                     }
-                    return new ElasticsearchResponse<DynamicResponse>(_templateExistsReturnCode, new[] { 200, 404 });
+                    return new ElasticsearchResponse<BulkResponse>(_templateExistsReturnCode, new[] { 200, 404 });
                 });
         }
 

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Elasticsearch.Net.2.0.2\lib\net45\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\..\packages\Elasticsearch.Net.2.0.4\lib\net45\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FakeItEasy">
@@ -46,15 +46,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NEST.2.0.2\lib\net45\Nest.dll</HintPath>
+      <HintPath>..\..\packages\NEST.2.0.4\lib\net45\Nest.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog">
       <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>

--- a/test/Serilog.Sinks.Elasticsearch.Tests/packages.config
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="2.0.2" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="2.0.4" targetFramework="net45" />
   <package id="FakeItEasy" version="1.25.3" targetFramework="net45" />
   <package id="FluentAssertions" version="4.2.2" targetFramework="net45" />
-  <package id="NEST" version="2.0.2" targetFramework="net45" />
+  <package id="NEST" version="2.0.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
-  <package id="NUnit" version="3.0.1" targetFramework="net45" />
+  <package id="NUnit" version="3.2.0" targetFramework="net45" />
   <package id="Serilog" version="1.5.14" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is the change which motivated me to update ES sink for NEST 2.0 compatibility. EmitBatchChecked return type is not very generic and hard to handle DynamicResponse, but rather very specific and much less error prone to handle BulkResponse. Result of ES bulk indexing request can be checked for success (and errors may be reported otherwise) much faster and easier than before.

This time net40 is not forgotten and all tests are passing!