### PR TITLE
Added possibility to override level names

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -132,6 +132,11 @@ namespace Serilog.Sinks.Elasticsearch
         public ITextFormatter CustomDurableFormatter { get; set; }
 
         /// <summary>
+        /// Customizes the names of the log event level names in the logged message. 
+        /// </summary>
+        public IDictionary<LogEventLevel, string> LogEventLevelNameOverrider { get; set; }
+
+        /// <summary>
         /// Configures the elasticsearch sink defaults
         /// </summary>
         protected ElasticsearchSinkOptions()
@@ -142,6 +147,7 @@ namespace Serilog.Sinks.Elasticsearch
             this.BatchPostingLimit = 50;
             this.TemplateName = "serilog-events-template";
             this.ConnectionTimeout = TimeSpan.FromSeconds(60);
+            this.LogEventLevelNameOverrider = new Dictionary<LogEventLevel, string>();
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
@@ -88,14 +88,17 @@ namespace Serilog.Sinks.Elasticsearch
                 renderMessage: true,
                 closingDelimiter: string.Empty,
                 serializer: options.Serializer,
-                inlineFields: options.InlineFields
+                inlineFields: options.InlineFields,
+                logEventLevelNames: options.LogEventLevelNameOverrider
+
             );
             _durableFormatter = options.CustomDurableFormatter ?? new ElasticsearchJsonFormatter(
                formatProvider: options.FormatProvider,
                renderMessage: true,
                closingDelimiter: Environment.NewLine,
                serializer: options.Serializer,
-               inlineFields: options.InlineFields
+               inlineFields: options.InlineFields,
+               logEventLevelNames:options.LogEventLevelNameOverrider
            );
 
             _registerTemplateOnStartup = options.AutoRegisterTemplate;

--- a/test/Serilog.Sinks.Elasticsearch.Tests/LevelValueDefaultValuesTest.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/LevelValueDefaultValuesTest.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Serilog.Sinks.Elasticsearch.Tests
+{
+    [TestFixture]
+    public class LevelValueDefaultValuesTest : ElasticsearchSinkTestsBase
+    {
+        [Test]
+        public void UseEnumValuesIfNotSet()
+        {
+            try
+            {
+                throw new Exception("Test");
+            }
+            catch (Exception e)
+            {
+                var messageTemplate = "{Song}++";
+                var template = new MessageTemplateParser().Parse(messageTemplate);
+                using (var sink = new ElasticsearchSink(_options))
+                {
+                    var properties = new List<LogEventProperty>
+                    {
+                        new LogEventProperty("Prop", new ScalarValue("Value")),
+                    };
+                    var logEvent = new LogEvent(DateTime.UtcNow, LogEventLevel.Information, e, template, properties);
+                    sink.Emit(logEvent);
+                    var logEvent2 = new LogEvent(DateTime.UtcNow, LogEventLevel.Error, e, template, properties);
+                    sink.Emit(logEvent2);
+                }
+                _seenHttpPosts.Should().NotBeEmpty().And.HaveCount(1);
+                var json = _seenHttpPosts.First();
+                var bulkJsonPieces = json.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                bulkJsonPieces.Should().HaveCount(4);
+                bulkJsonPieces[1].Should().Contain(@"""level"":""Information");
+                bulkJsonPieces[3].Should().Contain(@"""level"":""Error");
+            }
+        }
+    }
+}

--- a/test/Serilog.Sinks.Elasticsearch.Tests/LevelValueOverriderTest.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/LevelValueOverriderTest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Elasticsearch.Net;
+using FakeItEasy;
+using FluentAssertions;
+using NUnit.Framework;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Serilog.Sinks.Elasticsearch.Tests
+{
+    [TestFixture]
+    public class LevelValueOverriderTest : ElasticsearchSinkTestsBase
+    {
+        private static string _expectedInfomationValue = "InformationOverRidden";
+
+        public LevelValueOverriderTest() : base(new ElasticsearchSinkOptions(new Uri("http://localhost:9200"))
+        {
+            BatchPostingLimit = 2,
+            Period = TinyWait,
+            Connection = A.Fake<IConnection>(),
+            LogEventLevelNameOverrider = new Dictionary<LogEventLevel, string>()
+            {
+                {
+                    LogEventLevel.Information, _expectedInfomationValue
+                }
+            }
+
+        })
+        {
+
+        }
+
+        [Test]
+        public void UseDictionaryValuesIfPresent()
+        {
+            try
+            {
+                throw new Exception("Test");
+            }
+            catch (Exception e)
+            {
+                var messageTemplate = "{Song}++";
+                var template = new MessageTemplateParser().Parse(messageTemplate);
+                using (var sink = new ElasticsearchSink(_options))
+                {
+                    var properties = new List<LogEventProperty>
+                    {
+                        new LogEventProperty("Prop", new ScalarValue("Value")),
+                    };
+                    var logEvent = new LogEvent(DateTime.UtcNow, LogEventLevel.Information, e, template, properties);
+                    sink.Emit(logEvent);
+                    var logEvent2 = new LogEvent(DateTime.UtcNow, LogEventLevel.Error, e, template, properties);
+                    sink.Emit(logEvent2);
+                }
+                _seenHttpPosts.Should().NotBeEmpty().And.HaveCount(1);
+                var json = _seenHttpPosts.First();
+                var bulkJsonPieces = json.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                bulkJsonPieces.Should().HaveCount(4);
+                bulkJsonPieces[1].Should().Contain($@"""level"":""{_expectedInfomationValue}");
+                bulkJsonPieces[3].Should().Contain(@"""level"":""Error");
+            }
+        }
+    }
+}

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
@@ -82,6 +82,8 @@
     <Compile Include="InlineFieldsTests.cs" />
     <Compile Include="IndexDeciderTests.cs" />
     <Compile Include="ExceptionAsJsonObjectFormatterTests.cs" />
+    <Compile Include="LevelValueDefaultValuesTest.cs" />
+    <Compile Include="LevelValueOverriderTest.cs" />
     <Compile Include="RealExceptionNoSerializerTests.cs" />
     <Compile Include="RealExceptionTests.cs" />
     <Compile Include="PropertyNameTests.cs" />


### PR DESCRIPTION
Override log level names when serializing to match naming of other frameworks.

E.g. to match Bunyon (https://github.com/trentm/node-bunyan) Information should be logged as info.

This PR makes it possible to specify a text value for each log level. 