### PR TITLE
Upgrading solution to Serilog 2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+4.x
+ * *BREAKING CHANGE* This sink now uses Serilog 2.0. This is a breaking change, please use a version >=3.x of the sink if you want to use Serilog 1.x.
+
 3.0.130
  * Added an optional ExceptionAsJsonObjectFormatter to support serializing exceptions as a single object (not as an array).
  

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Serilog Elasticsearch sink project is a sink (basically a writer) for the Se
 - Be able to customize the store; specify the index name being used, the serializer or the connections to the server (load balanced).
 - Durable mode; store the logevents first on disk before delivering them to ES making sure you never miss events if you have trouble connecting to your ES cluster.
 - Automatically create the right mappings for the best usage of the log events in ES.
-- Version 3 is compatible with Elasticsearch 2.
+- Starting from version 3, compatible with Elasticsearch 2.
 
 ## Quick start
 
@@ -68,6 +68,10 @@ To use it, simply specify it as the `CustomFormatter` when creating the sink:
       CustomFormatter = new ExceptionAsJsonObjectFormatter(renderMessage:true)
     });
 ```
+### Breaking changes for version 4
+
+Starting from version 4, the sink has been upgraded to work with Serilog 2.0.
+
 ### Breaking changes for version 3
 
 Starting from version 3, the sink supports the Elasticsearch.Net 2 package and Elasticsearch version 2. If you need Elasticsearch 1.x support, then stick with version 2 of the sink.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 build_script:
-- ps: ./Build.ps1 -majorMinor "3.0" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- ps: ./Build.ps1 -majorMinor "4.0" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 artifacts:
 - path: Serilog.Sinks.Elasticsearch*.nupkg
 deploy:

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.Symbols.nuspec
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.Symbols.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging elasticsearch</tags>
     <dependencies>
-      <dependency id="Serilog" version="2" />
+      <dependency id="Serilog" version="2.0" />
       <dependency id="Elasticsearch.Net" version="2.3.3" />
     </dependencies>
   </metadata>

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.Symbols.nuspec
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.Symbols.nuspec
@@ -12,7 +12,10 @@
     <tags>serilog logging elasticsearch</tags>
     <dependencies>
       <dependency id="Serilog" version="2.0" />
-      <dependency id="Elasticsearch.Net" version="2.3.3" />
+      <dependency id="Elasticsearch.Net" version="2.4.1" />
+      <dependency id="Serilog.Sinks.File" version="2.1.0" />
+      <dependency id="Serilog.Sinks.PeriodicBatching" version="2.0.0" />
+      <dependency id="Serilog.Sinks.RollingFile" version="2.1.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.Symbols.nuspec
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.Symbols.nuspec
@@ -11,8 +11,8 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging elasticsearch</tags>
     <dependencies>
-      <dependency id="Serilog" version="[1.5.14,2)" />
-      <dependency id="Elasticsearch.Net" version="2.0.4" />
+      <dependency id="Serilog" version="2" />
+      <dependency id="Elasticsearch.Net" version="2.3.3" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.nuspec
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging elasticsearch</tags>
     <dependencies>
-      <dependency id="Serilog" version="2" />
+      <dependency id="Serilog" version="2.0" />
       <dependency id="Elasticsearch.Net" version="2.3.3" />
     </dependencies>
   </metadata>

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.nuspec
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.nuspec
@@ -12,7 +12,10 @@
     <tags>serilog logging elasticsearch</tags>
     <dependencies>
       <dependency id="Serilog" version="2.0" />
-      <dependency id="Elasticsearch.Net" version="2.3.3" />
+      <dependency id="Elasticsearch.Net" version="2.4.1" />
+      <dependency id="Serilog.Sinks.File" version="2.1.0" />
+      <dependency id="Serilog.Sinks.PeriodicBatching" version="2.0.0" />
+      <dependency id="Serilog.Sinks.RollingFile" version="2.1.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.nuspec
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.nuspec
@@ -11,8 +11,8 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging elasticsearch</tags>
     <dependencies>
-      <dependency id="Serilog" version="[1.5.14,2)" />
-      <dependency id="Elasticsearch.Net" version="2.0.4" />
+      <dependency id="Serilog" version="2" />
+      <dependency id="Elasticsearch.Net" version="2.3.3" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -47,7 +47,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Elasticsearch.Net.2.3.3\lib\net45\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\..\packages\Elasticsearch.Net.2.4.1\lib\net45\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
@@ -55,7 +55,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.Sinks.File.2.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.Sinks.File.2.1.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
@@ -63,7 +63,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.RollingFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.Sinks.RollingFile.2.0.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.Sinks.RollingFile.2.1.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -47,16 +47,24 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Elasticsearch.Net.2.0.4\lib\net45\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\..\packages\Elasticsearch.Net.2.3.3\lib\net45\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.File.2.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.PeriodicBatching.2.0.0\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.RollingFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.RollingFile.2.0.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchLogShipper.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchLogShipper.cs
@@ -130,7 +130,7 @@ namespace Serilog.Sinks.Elasticsearch
                     // Locking the bookmark ensures that though there may be multiple instances of this
                     // class running, only one will ship logs at a time.
 
-                    using (var bookmark = File.Open(_bookmarkFilename, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read))
+                    using (var bookmark = System.IO.File.Open(_bookmarkFilename, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read))
                     {
                         long nextLineBeginsAtOffset;
                         string currentFilePath;
@@ -139,7 +139,7 @@ namespace Serilog.Sinks.Elasticsearch
 
                         var fileSet = GetFileSet();
 
-                        if (currentFilePath == null || !File.Exists(currentFilePath))
+                        if (currentFilePath == null || !System.IO.File.Exists(currentFilePath))
                         {
                             nextLineBeginsAtOffset = 0;
                             currentFilePath = fileSet.FirstOrDefault();
@@ -164,7 +164,7 @@ namespace Serilog.Sinks.Elasticsearch
 
                         var payload = new List<string>();
 
-                        using (var current = File.Open(currentFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                        using (var current = System.IO.File.Open(currentFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                         {
                             current.Position = nextLineBeginsAtOffset;
 
@@ -215,7 +215,7 @@ namespace Serilog.Sinks.Elasticsearch
                                 // best to move on, though a lock on the current file
                                 // will delay this.
 
-                                File.Delete(fileSet[0]);
+                                System.IO.File.Delete(fileSet[0]);
                             }
                         }
                     }
@@ -243,7 +243,7 @@ namespace Serilog.Sinks.Elasticsearch
         {
             try
             {
-                using (var fileStream = File.Open(file, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read))
+                using (var fileStream = System.IO.File.Open(file, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read))
                 {
                     return fileStream.Length <= maxLen;
                 }

--- a/src/Serilog.Sinks.Elasticsearch/packages.config
+++ b/src/Serilog.Sinks.Elasticsearch/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="2.0.4" targetFramework="net45" />
-  <package id="Serilog" version="1.5.14" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="2.3.3" targetFramework="net45" />
+  <package id="Serilog" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.File" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.RollingFile" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/src/Serilog.Sinks.Elasticsearch/packages.config
+++ b/src/Serilog.Sinks.Elasticsearch/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="2.3.3" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="2.4.1" targetFramework="net45" />
   <package id="Serilog" version="2.0.0" targetFramework="net45" />
-  <package id="Serilog.Sinks.File" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.File" version="2.1.0" targetFramework="net45" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.0.0" targetFramework="net45" />
-  <package id="Serilog.Sinks.RollingFile" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.RollingFile" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTestsBase.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTestsBase.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -9,6 +8,7 @@ using FakeItEasy;
 using FluentAssertions;
 using Nest;
 using NUnit.Framework;
+using Serilog.Debugging;
 using Serilog.Sinks.Elasticsearch.Tests.Domain;
 
 namespace Serilog.Sinks.Elasticsearch.Tests
@@ -35,7 +35,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests
         }
         protected ElasticsearchSinkTestsBase()
         {
-            Serilog.Debugging.SelfLog.Out = Console.Out;
+            SelfLog.Enable(Console.Out);
             _serializer = new JsonNetSerializer(new ConnectionSettings());
             _connection = A.Fake<IConnection>();
             IConnectionPool connectionPool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
@@ -31,27 +31,27 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Elasticsearch.Net.2.3.3\lib\net45\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\..\packages\Elasticsearch.Net.2.4.1\lib\net45\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FakeItEasy, Version=2.1.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FakeItEasy.2.1.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions, Version=4.9.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.9.1\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.11.0\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.9.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.9.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.11.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NEST.2.3.3\lib\net45\Nest.dll</HintPath>
+      <HintPath>..\..\packages\NEST.2.4.1\lib\net45\Nest.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
@@ -31,37 +31,48 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Elasticsearch.Net, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Elasticsearch.Net.2.0.4\lib\net45\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\..\packages\Elasticsearch.Net.2.3.3\lib\net45\Elasticsearch.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy">
-      <HintPath>..\..\packages\FakeItEasy.1.25.3\lib\net40\FakeItEasy.dll</HintPath>
-    </Reference>
-    <Reference Include="FluentAssertions, Version=4.2.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.2.2\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=2.1.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FakeItEasy.2.1.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.2.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.2.2\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.9.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.9.1\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.9.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.9.1\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Nest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NEST.2.0.4\lib\net45\Nest.dll</HintPath>
+      <HintPath>..\..\packages\NEST.2.3.3\lib\net45\Nest.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.Enrichers.Environment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Enrichers.Environment.2.0.0\lib\net45\Serilog.Enrichers.Environment.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.ColoredConsole, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.ColoredConsole.2.0.0\lib\net45\Serilog.Sinks.ColoredConsole.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.PeriodicBatching.2.0.0\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -94,6 +105,7 @@
     <Compile Include="TestDataHelper.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Templating/SendsTemplateHandlesUnavailableServerTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Templating/SendsTemplateHandlesUnavailableServerTests.cs
@@ -21,7 +21,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests.Templating
         public void Should_write_error_to_self_log()
         {
             var selfLogMessages = new StringBuilder();
-            SelfLog.Out = new StringWriter(selfLogMessages);
+            SelfLog.Enable(new StringWriter(selfLogMessages));
 
             // Exception occurs on creation - should be logged
             CreateLoggerThatCrashes();

--- a/test/Serilog.Sinks.Elasticsearch.Tests/app.config
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/Serilog.Sinks.Elasticsearch.Tests/packages.config
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/packages.config
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="2.0.4" targetFramework="net45" />
-  <package id="FakeItEasy" version="1.25.3" targetFramework="net45" />
-  <package id="FluentAssertions" version="4.2.2" targetFramework="net45" />
-  <package id="NEST" version="2.0.4" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="2.3.3" targetFramework="net45" />
+  <package id="FakeItEasy" version="2.1.0" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.9.1" targetFramework="net45" />
+  <package id="NEST" version="2.3.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
-  <package id="NUnit" version="3.2.0" targetFramework="net45" />
-  <package id="Serilog" version="1.5.14" targetFramework="net45" />
+  <package id="NUnit" version="3.4.1" targetFramework="net45" />
+  <package id="Serilog" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog.Enrichers.Environment" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.ColoredConsole" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/test/Serilog.Sinks.Elasticsearch.Tests/packages.config
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="2.3.3" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="2.4.1" targetFramework="net45" />
   <package id="FakeItEasy" version="2.1.0" targetFramework="net45" />
-  <package id="FluentAssertions" version="4.9.1" targetFramework="net45" />
-  <package id="NEST" version="2.3.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.11.0" targetFramework="net45" />
+  <package id="NEST" version="2.4.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
   <package id="Serilog" version="2.0.0" targetFramework="net45" />
   <package id="Serilog.Enrichers.Environment" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
Trying to address #45.

Updated Serilog.Sinks.Elasticsearch and Serilog.Sinks.Elasticsearch.Tests to use Serilog 2.0 (including adding references to the newer nuget packages for PeriodicBatching, RollingFile, etc.).

Also updated all the nuget dependencies to the latest versions:
- In main project: Elasticsearch.Net 2.3.3
- In test project: Elasticsearch.Net, NEST, FakeItEasy, FluentAssertions, NUnit.

Unit tests are passing, but haven't run integration tests with a real elasticsearch instance.

Also, I haven't touched serilog-sinks-elasticsearch-net40.sln; I believe Serilog 2.0 dropped support for .NET 4.0, so not sure what should be done with this :)

Hope this helps, please let me know if anything else would be required!

Thanks,
chuwik