### PR TITLE
Backport exponential backoff into v2

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch-net40.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch-net40.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Sinks\ElasticSearch\ElasticSearchSink.cs" />
     <Compile Include="Sinks\ElasticSearch\ElasticsearchSinkOptions.cs" />
     <Compile Include="Sinks\ElasticSearch\ElasticsearchSinkState.cs" />
+    <Compile Include="Sinks\ElasticSearch\ExponentialBackoffConnectionSchedule.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\assets\Serilog.snk">

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Sinks\Elasticsearch\ElasticsearchSink.cs" />
     <Compile Include="Sinks\Elasticsearch\ElasticsearchSinkOptions.cs" />
     <Compile Include="Sinks\Elasticsearch\ElasticsearchSinkState.cs" />
+    <Compile Include="Sinks\Elasticsearch\ExponentialBackoffConnectionSchedule.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\assets\Serilog.snk">

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchLogShipper.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchLogShipper.cs
@@ -36,6 +36,7 @@ namespace Serilog.Sinks.Elasticsearch
         readonly string _bookmarkFilename;
         readonly string _logFolder;
         readonly string _candidateSearchPath;
+        readonly ExponentialBackoffConnectionSchedule _connectionSchedule;
 
         bool _didRegisterTemplateIfNeeded;
 
@@ -47,6 +48,7 @@ namespace Serilog.Sinks.Elasticsearch
             _bookmarkFilename = Path.GetFullPath(_state.Options.BufferBaseFilename + ".bookmark");
             _logFolder = Path.GetDirectoryName(_bookmarkFilename);
             _candidateSearchPath = Path.GetFileName(_state.Options.BufferBaseFilename) + "*.json";
+            _connectionSchedule = new ExponentialBackoffConnectionSchedule(_state.Options.BufferLogShippingInterval ?? TimeSpan.FromSeconds(5));
 
             _timer = new Timer(s => OnTick());
 
@@ -106,7 +108,7 @@ namespace Serilog.Sinks.Elasticsearch
             // Note, called under _stateLock
             var infiniteTimespan = TimeSpan.FromMilliseconds(Timeout.Infinite); //< can't use Timeout.InfiniteTimespan in .NET 4
 
-            _timer.Change(_period, infiniteTimespan);
+            _timer.Change(_connectionSchedule.NextInterval, infiniteTimespan);
         }
 
         void OnTick()
@@ -183,14 +185,22 @@ namespace Serilog.Sinks.Elasticsearch
                             if (response.Success)
                             {
                                 WriteBookmark(bookmark, nextLineBeginsAtOffset, currentFilePath);
+                                _connectionSchedule.MarkSuccess();
                             }
                             else
                             {
+                                _connectionSchedule.MarkFailure();
                                 SelfLog.WriteLine("Received failed ElasticSearch shipping result {0}: {1}", response.HttpStatusCode, response.OriginalException);
+                                SelfLog.WriteLine("Will wait {0} seconds before retry", _connectionSchedule.NextInterval);
+                                break;
                             }
                         }
                         else
                         {
+                            // For whatever reason, there's nothing waiting to send. This means we should try connecting again at the
+                            // regular interval, so mark the attempt as successful.
+                            _connectionSchedule.MarkSuccess();
+
                             // Only advance the bookmark if no other process has the
                             // current file locked, and its length is as we found it.
 
@@ -215,6 +225,8 @@ namespace Serilog.Sinks.Elasticsearch
             catch (Exception ex)
             {
                 SelfLog.WriteLine("Exception while emitting periodic batch from {0}: {1}", this, ex);
+                _connectionSchedule.MarkFailure();
+                SelfLog.WriteLine("Will wait {0} before retry", _connectionSchedule.NextInterval);
             }
             finally
             {

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ExponentialBackoffConnectionSchedule.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ExponentialBackoffConnectionSchedule.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2016 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Serilog.Sinks.Elasticsearch
+{
+    /// <summary>
+    /// Based on the BatchedConnectionStatus class from <see cref="Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink"/>.
+    /// </summary>
+    class ExponentialBackoffConnectionSchedule
+    {
+        static readonly TimeSpan MinimumBackoffPeriod = TimeSpan.FromSeconds(5);
+        static readonly TimeSpan MaximumBackoffInterval = TimeSpan.FromMinutes(10);
+
+        readonly TimeSpan _period;
+
+        int _failuresSinceSuccessfulConnection;
+
+        public ExponentialBackoffConnectionSchedule(TimeSpan period)
+        {
+            if (period < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period), "The connection retry period must be a positive timespan");
+
+            _period = period;
+        }
+
+        public void MarkSuccess()
+        {
+            _failuresSinceSuccessfulConnection = 0;
+        }
+
+        public void MarkFailure()
+        {
+            ++_failuresSinceSuccessfulConnection;
+        }
+
+        public TimeSpan NextInterval
+        {
+            get
+            {
+                // Available, and first failure, just try the batch interval
+                if (_failuresSinceSuccessfulConnection <= 1) return _period;
+
+                // Second failure, start ramping up the interval - first 2x, then 4x, ...
+                var backoffFactor = Math.Pow(2, (_failuresSinceSuccessfulConnection - 1));
+
+                // If the period is ridiculously short, give it a boost so we get some
+                // visible backoff.
+                var backoffPeriod = Math.Max(_period.Ticks, MinimumBackoffPeriod.Ticks);
+
+                // The "ideal" interval
+                var backedOff = (long)(backoffPeriod * backoffFactor);
+
+                // Capped to the maximum interval
+                var cappedBackoff = Math.Min(MaximumBackoffInterval.Ticks, backedOff);
+
+                // Unless that's shorter than the base interval, in which case we'll just apply the period
+                var actual = Math.Max(_period.Ticks, cappedBackoff);
+
+                return TimeSpan.FromTicks(actual);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Unfortunately we're stuck on ES 1.5 so have to stick with the 2.x clients, however with our production workloads the exponential backoff functionality is very important for when we need to perform cluster maintenance. I've backported the code from 4.x and everything works great.

I've created a temporary package in nuget for anyone who wants this feature today:
https://www.nuget.org/packages/Serilog.Sinks.Elasticsearch.Backoff/2.2.0

Thanks,