### PR TITLE
Corrected spelling of ExceptionAsObjectJsonFormatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
  * *BREAKING CHANGE* This sink now uses Serilog 2.0. This is a breaking change, please use a version >=3.x of the sink if you want to use Serilog 1.x.
 
 3.0.130
- * Added an optional ExceptionAsJsonObjectFormatter to support serializing exceptions as a single object (not as an array).
+ * Added an optional ExceptionAsObjectJsonFormatter to support serializing exceptions as a single object (not as an array).
  
 3.0.128
  * SpecificVersion set to False in order not to be dependent on a version of Elasticsearch or Serilog.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In order to avoid a potentially deeply nested JSON structure for exceptions with
 by default the logged exception and it's inner exception is logged as an array of exceptions in the field `exceptions`. Use the 'Depth' field to traverse the inner exceptions flow. 
 
 However, not all features in Kibana work just as well with JSON arrays - for instance, including
-exception fields on dashboards and visualizations. Therefore, we provide an alternative formatter,  `ExceptionAsJsonObjectFormatter`, which will serialize the exception into the `exception` field as an object with nested `InnerException` properties. This was also the default behaviour of the sink before version 2.
+exception fields on dashboards and visualizations. Therefore, we provide an alternative formatter,  `ExceptionAsObjectJsonFormatter`, which will serialize the exception into the `exception` field as an object with nested `InnerException` properties. This was also the default behaviour of the sink before version 2.
 
 To use it, simply specify it as the `CustomFormatter` when creating the sink:
 


### PR DESCRIPTION
`ExceptionAsObjectJsonFormatter` was incorrectly written as `ExceptionAsJsonObjectFormatter` in the documentation.