### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Instead of configuring the sink directly in code, call `ReadFrom.Configuration()
 
 ```csharp
 var configuration = new ConfigurationBuilder()
+    .SetBasePath(env.ContentRootPath)
     .AddJsonFile("appsettings.json")
     .Build();
 


### PR DESCRIPTION
Update documentation to use .SetBasePath when configuring appsettings.json to avoid System.IO.FileNotFoundException.