### PR TITLE
Custom Json formatter that treats a specified destructing property as the main elasticsearch source

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,42 @@ And start writing your events using Serilog.
 - Report issues to the [issue tracker](https://github.com/serilog/serilog-sinks-elasticsearch/issues). PR welcome, but please do this against the dev branch.
 - For an overview of recent changes, have a look at the [change log](https://github.com/serilog/serilog-sinks-elasticsearch/blob/master/CHANGES.md).
 
+### Treating a specified property as source in ElasticSearch
+
+Custom Json formatter that treats a specified destructing property as the full source.
+Suitable for situations where you want only your destructed property as the content 
+that ends up in elasticsearch and want to avoid any other extra information. For example
+if your object if fully self contained with its own timestamp and everything then you would 
+want to avoid the extra time and other properties added by the json formatter and also want to
+avoid your main object appearing as a property of another top level object.
+For example if your object has properties Timestamp, Level, Prop1 and Prop2 then it will look like the following
+in elasticearch and no other extra information will be added if you log it like 
+
+```csharp
+_seriLogger.Information("{@MyProperty}", new {Timestamp = DateTime.UtcNow, Level="Error", Prop1="Prop1value", Prop2="Prop2Value"});
+```
+
+then it appears as the following json in elasticearch:
+
+```json
+"_source": {
+	"Timestamp": "2017-01-03T04:17:24.7896225Z",
+    "Level": "Information",
+	"Prop1": "Prop1value",
+	"Prop2": "Prop2Value"
+} 
+```
+To use it, simply specify it as the `CustomFormatter` when creating the sink:
+
+```csharp
+    new ElasticsearchSink(new ElasticsearchSinkOptions(url)
+    {
+		CustomFormatter = new TreatPropertyAsSourceElasticsearchJsonFormatter("MyProperty")
+    });
+```
+where MyProperty is name that appears in the destructing template like "{@MyProperty}" as above.
+
+
 ### A note about Kibana
 
 In order to avoid a potentially deeply nested JSON structure for exceptions with inner exceptions,

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/TreatPropertyAsSourceElasticsearchJsonFormatter.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/TreatPropertyAsSourceElasticsearchJsonFormatter.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Elasticsearch.Net;
+using Serilog.Events;
+
+namespace Serilog.Sinks.Elasticsearch.Sinks.ElasticSearch
+{
+    /// <summary>
+    /// Custom Json formatter that treats a specified destructing property as the full source.
+    /// Suitable for situations where you want only your destructed property as the content 
+    /// that ends up in elasticsearch and want to avoid any other extra information. For example
+    /// if your object if fully self contained with its own timestamp and everything then you would 
+    /// want to avoid the extra time and other properties added by the json formatter and also want to
+    /// avoid your main object appearing as a property of another top level object.
+    /// For example if your object has properties Timestamp and Level then it will look like the following
+    /// in elasticearch and no other extra information will be added
+    ///     "_source": {
+    ///        "Timestamp": "2017-01-03T10:56:56.0000000+11:00",
+    ///        "Level": "Information",
+    ///      } 
+    /// </summary>
+    public class TreatPropertyAsSourceElasticsearchJsonFormatter : ElasticsearchJsonFormatter
+    {
+        private readonly string _propertyNameToBeTreatedAsSource;
+
+        /// <summary>
+        /// Construct a <see cref="TreatPropertyAsSourceElasticsearchJsonFormatter"/>.
+        /// </summary>
+        /// <param name="propertyNameToBeTreatedAsSource">
+        /// This is the property that will be assigned as the elasticsearch source. For example if you are writing the property like
+        /// Logger.Information("@MyProperty", myProperty) then myProperty will become the root object and its properties will be become the 
+        /// properties of the _source object. For example if myProperty has properties Timestamp and Level then it will look like the following
+        /// in elasticearch and no other extra information will be added
+        ///     "_source": {
+        ///        "Timestamp": "2017-01-03T10:56:56.0000000+11:00",
+        ///        "Level": "Information",
+        ///      }
+        /// </param>
+        /// <param name="omitEnclosingObject">If true, the properties of the event will be written to
+        /// the output without enclosing braces. Otherwise, if false, each event will be written as a well-formed
+        /// JSON object.</param>
+        /// <param name="closingDelimiter">A string that will be written after each log event is formatted.
+        /// If null, <see cref="Environment.NewLine"/> will be used. Ignored if <paramref name="omitEnclosingObject"/>
+        /// is true.</param>
+        /// <param name="renderMessage">If true, the message will be rendered and written to the output as a
+        /// property named RenderedMessage.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="serializer">Inject a serializer to force objects to be serialized over being ToString()</param>
+        /// <param name="inlineFields">When set to true values will be written at the root of the json document</param>
+        public TreatPropertyAsSourceElasticsearchJsonFormatter(string propertyNameToBeTreatedAsSource, bool omitEnclosingObject = false, string closingDelimiter = null,
+            bool renderMessage = false,
+            IFormatProvider formatProvider = null, IElasticsearchSerializer serializer = null, bool inlineFields = false)
+            : base(omitEnclosingObject, closingDelimiter, renderMessage,
+                formatProvider, serializer, inlineFields)
+        {
+            _propertyNameToBeTreatedAsSource = propertyNameToBeTreatedAsSource.ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Writes the _propertyNameToBeTreatedAsSource property as the _source for Object and Dictionary types
+        /// This will behave exactly as ElasticsearchJsonFormatter if _propertyNameToBeTreatedAsSource is NOT specified
+        /// </summary>
+        protected override void WriteProperties(IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+        {
+            var precedingDelimiter = "";
+            foreach (var property in properties)
+            {
+                if (property.Key.ToLowerInvariant() == _propertyNameToBeTreatedAsSource)
+                {
+                    if (property.Value is DictionaryValue)
+                        WriteDictionaryWithoutWrapping(((DictionaryValue)property.Value).Elements, output);
+                    else if (property.Value is StructureValue)
+                        WriteStructureWithoutWrapping(((StructureValue)property.Value).Properties, output);
+                    else
+                        WriteJsonProperty(property.Key, property.Value, ref precedingDelimiter, output);
+                }
+                else
+                    WriteJsonProperty(property.Key, property.Value, ref precedingDelimiter, output);
+            }
+        }
+        /// <summary>
+        /// Writes out the Structure without Wrapping in any top level object
+        /// </summary>
+        protected void WriteStructureWithoutWrapping(IEnumerable<LogEventProperty> properties, TextWriter output)
+        {
+            var delim = "";
+
+            foreach (var property in properties)
+                WriteJsonProperty(property.Name, property.Value, ref delim, output);
+        }
+
+        /// <summary>
+        /// Writes out the Dictionary without Wrapping in any top level object
+        /// </summary>
+        protected void WriteDictionaryWithoutWrapping(IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> elements, TextWriter output)
+        {
+            var delim = "";
+
+            foreach (var e in elements)
+                WriteJsonProperty(e.Key.Value.ToString(), e.Value, ref delim, output);
+        }
+
+        /// <summary>
+        /// Writes out the Structure without any other extra properties like _typeTag etc.
+        /// </summary>
+        protected override void WriteStructure(string typeTag, IEnumerable<LogEventProperty> properties, TextWriter output)
+        {
+            output.Write("{");
+
+            var delim = "";
+
+            foreach (var property in properties)
+                WriteJsonProperty(property.Name, property.Value, ref delim, output);
+
+            output.Write("}");
+        }
+
+        /// <summary>
+        /// Do not write any extra message
+        /// </summary>
+        protected override void WriteRenderedMessage(string message, ref string delim, TextWriter output)
+        {
+            // do nothing
+        }
+
+        /// <summary>
+        /// Do not write any message template
+        /// </summary>
+        protected override void WriteMessageTemplate(string template, ref string delim, TextWriter output)
+        {
+            // do nothing
+        }
+
+        /// <summary>
+        /// Do not write any extra level as it is likely part of the destructed logged object already
+        /// </summary>
+        protected override void WriteLevel(LogEventLevel level, ref string delim, TextWriter output)
+        {
+            // do nothing
+        }
+
+        /// <summary>
+        /// Do not write any extra timestamp as it is likely part of the destructed logged object already
+        /// </summary>
+        protected override void WriteTimestamp(DateTimeOffset timestamp, ref string delim, TextWriter output)
+        {
+            // do nothing
+
+        }
+    }
+}

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/TreatPropertyAsSourceElasticsearchJsonFormatter.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/TreatPropertyAsSourceElasticsearchJsonFormatter.cs
@@ -37,22 +37,8 @@ namespace Serilog.Sinks.Elasticsearch.Sinks.ElasticSearch
         ///        "Level": "Information",
         ///      }
         /// </param>
-        /// <param name="omitEnclosingObject">If true, the properties of the event will be written to
-        /// the output without enclosing braces. Otherwise, if false, each event will be written as a well-formed
-        /// JSON object.</param>
-        /// <param name="closingDelimiter">A string that will be written after each log event is formatted.
-        /// If null, <see cref="Environment.NewLine"/> will be used. Ignored if <paramref name="omitEnclosingObject"/>
-        /// is true.</param>
-        /// <param name="renderMessage">If true, the message will be rendered and written to the output as a
-        /// property named RenderedMessage.</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="serializer">Inject a serializer to force objects to be serialized over being ToString()</param>
-        /// <param name="inlineFields">When set to true values will be written at the root of the json document</param>
-        public TreatPropertyAsSourceElasticsearchJsonFormatter(string propertyNameToBeTreatedAsSource, bool omitEnclosingObject = false, string closingDelimiter = null,
-            bool renderMessage = false,
-            IFormatProvider formatProvider = null, IElasticsearchSerializer serializer = null, bool inlineFields = false)
-            : base(omitEnclosingObject, closingDelimiter, renderMessage,
-                formatProvider, serializer, inlineFields)
+        public TreatPropertyAsSourceElasticsearchJsonFormatter(string propertyNameToBeTreatedAsSource)
+            : base(renderMessage:false, inlineFields:true)
         {
             _propertyNameToBeTreatedAsSource = propertyNameToBeTreatedAsSource.ToLowerInvariant();
         }

--- a/src/Serilog.Sinks.Elasticsearch/project.json
+++ b/src/Serilog.Sinks.Elasticsearch/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "4.1.0-unstable0157",
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../assets/Serilog.snk",

--- a/src/Serilog.Sinks.Elasticsearch/project.json
+++ b/src/Serilog.Sinks.Elasticsearch/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.1.0-unstable0157",
+  "version": "4.1.0-unstable0158",
   "buildOptions": {
     "warningsAsErrors": true,
     "keyFile": "../../assets/Serilog.snk",

--- a/test/Serilog.Sinks.Elasticsearch.Tests/TreatPropertyAsSourceElasticSearchJsonFormatterTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/TreatPropertyAsSourceElasticSearchJsonFormatterTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using Serilog.Events;
+using Serilog.Parsing;
+using Serilog.Sinks.Elasticsearch.Sinks.ElasticSearch;
+using Xunit;
+using FluentAssertions;
+
+namespace Serilog.Sinks.Elasticsearch.Tests
+{
+    public class TreatPropertyAsSourceElasticSearchJsonFormatterTests : ElasticsearchSinkTestsBase
+    {
+        [Fact]
+        public async Task TreatPropertyAsSource()
+        {
+            using (var sink = new ElasticsearchSink(new ElasticsearchSinkOptions(
+                new SingleNodeConnectionPool(new Uri("http://localhost:9200")))
+            {
+                BatchPostingLimit = 2,
+                Connection = _connection,
+                InlineFields = true,
+                CustomFormatter = new TreatPropertyAsSourceElasticsearchJsonFormatter("MyProperty")
+            }))
+            {
+                var properties = new List<LogEventProperty>
+                    {
+                        new LogEventProperty("MyProperty", new StructureValue(new List<LogEventProperty>()
+                        {
+                            new LogEventProperty("Timestamp", new ScalarValue("2017-01-03T03:28:54.5776763Z")),
+                            new LogEventProperty("Level", new ScalarValue("Error")),
+                            new LogEventProperty("Prop1", new ScalarValue("Prop1Value")),
+                            new LogEventProperty("Prop2", new ScalarValue("Prop2Value")),
+                        } )),
+                    };
+
+                sink.Emit(new LogEvent(DateTime.Now, LogEventLevel.Information, null, new MessageTemplateParser().Parse("@MyProperty"), properties));
+                sink.Emit(new LogEvent(DateTime.Now, LogEventLevel.Information, null, new MessageTemplateParser().Parse("@MyProperty"), properties));
+                
+            }
+            var bulkJsonPieces = this.AssertSeenHttpPosts(_seenHttpPosts, 4);
+            bulkJsonPieces[1].ShouldBeEquivalentTo(
+                "{\"Timestamp\":\"2017-01-03T03:28:54.5776763Z\",\"Level\":\"Error\",\"Prop1\":\"Prop1Value\",\"Prop2\":\"Prop2Value\"}\r");
+            
+        }
+    }
+}

--- a/test/Serilog.Sinks.Elasticsearch.Tests/TreatPropertyAsSourceElasticSearchJsonFormatterTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/TreatPropertyAsSourceElasticSearchJsonFormatterTests.cs
@@ -14,7 +14,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests
     public class TreatPropertyAsSourceElasticSearchJsonFormatterTests : ElasticsearchSinkTestsBase
     {
         [Fact]
-        public async Task TreatPropertyAsSource()
+        public void TreatPropertyAsSource()
         {
             using (var sink = new ElasticsearchSink(new ElasticsearchSinkOptions(
                 new SingleNodeConnectionPool(new Uri("http://localhost:9200")))

--- a/test/Serilog.Sinks.Elasticsearch.Tests/TreatPropertyAsSourceElasticSearchJsonFormatterTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/TreatPropertyAsSourceElasticSearchJsonFormatterTests.cs
@@ -38,7 +38,9 @@ namespace Serilog.Sinks.Elasticsearch.Tests
 
                 sink.Emit(new LogEvent(DateTime.Now, LogEventLevel.Information, null, new MessageTemplateParser().Parse("@MyProperty"), properties));
                 sink.Emit(new LogEvent(DateTime.Now, LogEventLevel.Information, null, new MessageTemplateParser().Parse("@MyProperty"), properties));
-                
+                sink.Emit(new LogEvent(DateTime.Now, LogEventLevel.Information, null, new MessageTemplateParser().Parse("@MyProperty"), properties));
+
+
             }
             var bulkJsonPieces = this.AssertSeenHttpPosts(_seenHttpPosts, 4);
             bulkJsonPieces[1].ShouldBeEquivalentTo(


### PR DESCRIPTION
Custom Json formatter that treats a specified destructing property as the full source.
Suitable for situations where you want only your destructed property as the content 
that ends up in elasticsearch and want to avoid any other extra information. For example
if your object if fully self contained with its own timestamp and everything then you would 
want to avoid the extra time and other properties added by the json formatter and also want to
avoid your main object appearing as a property of another top level object.
For example if your object has properties Timestamp, Level, Prop1 and Prop2 then it will look like the following in elasticearch and no other extra information will be added if you log it like 

_seriLogger.Information("{@MyProperty}", new {Timestamp = DateTime.UtcNow, Level="Error", Prop1="Prop1value", Prop2="Prop2Value"});

then it appears as the following json in elasticearch:

"_source": {
	"Timestamp": "2017-01-03T04:17:24.7896225Z",
        "Level": "Information",
	"Prop1": "Prop1value",
	"Prop2": "Prop2Value"
} 

To use it, simply specify it as the `CustomFormatter` when creating the sink:
    new ElasticsearchSink(new ElasticsearchSinkOptions(url)
    {
		CustomFormatter = new TreatPropertyAsSourceElasticsearchJsonFormatter("MyProperty")
    });

where MyProperty is name that appears in the destructing template like "{@MyProperty}" as above.