### PR TITLE
#87 Add Support for specifying Http Headers in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ This example shows the options that are currently available when using the appSe
     <add key="serilog:write-to:Elasticsearch.minimumLogEventLevel" value="Warning"/>
     <add key="serilog:write-to:Elasticsearch.bufferBaseFilename" value="C:\Temp\SerilogElasticBuffer"/>
     <add key="serilog:write-to:Elasticsearch.bufferFileSizeLimitBytes" value="5242880"/>
-    <add key="serilog:write-to:Elasticsearch.bufferLogShippingInterval" value="5000"/>
+    <add key="serilog:write-to:Elasticsearch.bufferLogShippingInterval" value="5000"/>	
+	<add key="serilog:write-to:Elasticsearch.connectionGlobalHeaders" value="Authorization=Bearer SOME-TOKEN;OtherHeader=OTHER-HEADER-VALUE" />
   </appSettings>
 ```
 
@@ -118,7 +119,8 @@ In your `appsettings.json` file, under the `Serilog` node, :
           "minimumLogEventLevel": "Warning",
           "bufferBaseFilename":  "C:/Temp/LogDigipolis/docker-elk-serilog-web-buffer",
           "bufferFileSizeLimitBytes": 5242880,
-          "bufferLogShippingInterval": 5000
+          "bufferLogShippingInterval": 5000,
+		  "connectionGlobalHeaders" :"Authorization=Bearer SOME-TOKEN;OtherHeader=OTHER-HEADER-VALUE"
         }       
     }]
   }


### PR DESCRIPTION
#87 developers can specify http headers in the config file like:
<add key="serilog:write-to:Elasticsearch.connectionGlobalHeaders" value="Authorization=Bearer SOME-TOKEN;OtherHeader=OTHER-HEADER-VALUE" />
for elastic servers that require Authorization header.
the parameter is not mandatory.

this solves also issue #75 