### PR TITLE
Don't restrict to Information level when no mum is specified

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -49,10 +49,6 @@ namespace Serilog
             this LoggerSinkConfiguration loggerSinkConfiguration,
             ElasticsearchSinkOptions options = null)
         {
-            //TODO make sure we do not kill appdata injection
-            //TODO handle bulk errors and write to self log, what does logstash do in this case?
-            //TODO NEST trace logging ID's to corrolate requests to eachother
-
             options = options ?? new ElasticsearchSinkOptions(new[] { new Uri(DefaultNodeUri) });
 
             var sink = string.IsNullOrWhiteSpace(options.BufferBaseFilename)
@@ -73,11 +69,11 @@ namespace Serilog
         /// <param name="batchPostingLimit"><see cref="ElasticsearchSinkOptions.BatchPostingLimit"/></param>
         /// <param name="period"><see cref="ElasticsearchSinkOptions.Period"/></param>
         /// <param name="inlineFields"><see cref="ElasticsearchSinkOptions.InlineFields"/></param>
-        /// <param name="minimumLogEventLevel"><see cref="ElasticsearchSinkOptions.MinimumLogEventLevel"/></param>
+        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="bufferBaseFilename"><see cref="ElasticsearchSinkOptions.BufferBaseFilename"/></param>
         /// <param name="bufferFileSizeLimitBytes"><see cref="ElasticsearchSinkOptions.BufferFileSizeLimitBytes"/></param>
         /// <param name="bufferLogShippingInterval"><see cref="ElasticsearchSinkOptions.BufferLogShippingInterval"/></param>
-        /// <param name="connectionGlobalHeaders">A comma or semi column separated list of key value pairs of headers to be added to each elastic http request</param>        
+        /// <param name="connectionGlobalHeaders">A comma or semi column separated list of key value pairs of headers to be added to each elastic http request</param>   
         /// <returns>LoggerConfiguration object</returns>
         /// <exception cref="ArgumentNullException"><paramref name="nodeUris"/> is <see langword="null" />.</exception>
         public static LoggerConfiguration Elasticsearch(
@@ -89,7 +85,7 @@ namespace Serilog
             int batchPostingLimit = 50,
             int period = 2,
             bool inlineFields = false,
-            LogEventLevel minimumLogEventLevel = LogEventLevel.Information,
+            LogEventLevel minimumLogEventLevel = LevelAlias.Minimum,
             string bufferBaseFilename = null,
             long? bufferFileSizeLimitBytes = null,
             long bufferLogShippingInterval = 5000,
@@ -152,7 +148,6 @@ namespace Serilog
 
                 options.ModifyConnectionSettings = (c) => c.GlobalHeaders(headers);
             }
-
 
             return Elasticsearch(loggerSinkConfiguration, options);
         }

--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -69,7 +69,7 @@ namespace Serilog
         /// <param name="batchPostingLimit"><see cref="ElasticsearchSinkOptions.BatchPostingLimit"/></param>
         /// <param name="period"><see cref="ElasticsearchSinkOptions.Period"/></param>
         /// <param name="inlineFields"><see cref="ElasticsearchSinkOptions.InlineFields"/></param>
-        /// <param name="minimumLogEventLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="bufferBaseFilename"><see cref="ElasticsearchSinkOptions.BufferBaseFilename"/></param>
         /// <param name="bufferFileSizeLimitBytes"><see cref="ElasticsearchSinkOptions.BufferFileSizeLimitBytes"/></param>
         /// <param name="bufferLogShippingInterval"><see cref="ElasticsearchSinkOptions.BufferLogShippingInterval"/></param>
@@ -85,7 +85,7 @@ namespace Serilog
             int batchPostingLimit = 50,
             int period = 2,
             bool inlineFields = false,
-            LogEventLevel minimumLogEventLevel = LevelAlias.Minimum,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string bufferBaseFilename = null,
             long? bufferFileSizeLimitBytes = null,
             long bufferLogShippingInterval = 5000,
@@ -119,7 +119,7 @@ namespace Serilog
             options.BatchPostingLimit = batchPostingLimit;
             options.Period = TimeSpan.FromSeconds(period);
             options.InlineFields = inlineFields;
-            options.MinimumLogEventLevel = minimumLogEventLevel;
+            options.MinimumLogEventLevel = restrictedToMinimumLevel;
 
             if (!string.IsNullOrWhiteSpace(bufferBaseFilename))
             {

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -26,7 +26,6 @@ namespace Serilog.Sinks.Elasticsearch
     /// </summary>
     public class ElasticsearchSinkOptions
     {
-
         /// <summary>
         /// When set to true the sink will register an index template for the logs in elasticsearch.
         /// This template is optimized to deal with serilog events
@@ -116,7 +115,6 @@ namespace Serilog.Sinks.Elasticsearch
         /// Function to decide which index to write the LogEvent to
         /// </summary>
         public Func<LogEvent, DateTimeOffset, string> IndexDecider { get; set; }
-
 
         /// <summary>
         /// Optional path to directory that can be used as a log shipping buffer for increasing the reliability of the log forwarding.


### PR DESCRIPTION
Sinks don't normally restrict the minimum log event level unless explicitly told to do so. The configuration overload accepting `ElasticsearchSinkOptions` respects this convention, but the appsettings compatible overload does not.

The change removes this default limitation. This might be surprising to some users - if we want to go so far as to consider it a major-version incrementing breaking change, we might wish to also rename the parameter `restrictedToMinimumLevel`, which is the name used by all other Serilog sinks for this (ES is alone in calling this parameter `minimumLogEventLevel`).

Thoughts?

Fixes #93.