### PR TITLE
support config global headers that contains equal sign ('=') in its v…

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -142,7 +142,7 @@ namespace Serilog
                     .ToList()
                     .ForEach(headerValueStr =>
                     {
-                        var headerValue = headerValueStr.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries);
+                        var headerValue = headerValueStr.Split(new[] { '=' }, 2, StringSplitOptions.RemoveEmptyEntries);
                         headers.Add(headerValue[0], headerValue[1]);
                     });
 


### PR DESCRIPTION
support config global headers that contains equal sign ('=') in its value
suggested by @CumpsD, on PR #87 