### PR TITLE
Added logLevelSwitch option

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -58,7 +58,7 @@ namespace Serilog
             return loggerSinkConfiguration.Sink(
                 sink,
                 restrictedToMinimumLevel : options.MinimumLogEventLevel ?? LevelAlias.Minimum,
-                levelSwitch : options.LoggingLevelSwitch
+                levelSwitch : options.LevelSwitch
             );
         }
 
@@ -73,8 +73,8 @@ namespace Serilog
         /// <param name="batchPostingLimit"><see cref="ElasticsearchSinkOptions.BatchPostingLimit"/></param>
         /// <param name="period"><see cref="ElasticsearchSinkOptions.Period"/></param>
         /// <param name="inlineFields"><see cref="ElasticsearchSinkOptions.InlineFields"/></param>
-        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink. Ignored when <paramref name="loggingLevelSwitch"/> is specified.</param>
-        /// <param name="loggingLevelSwitch" > A switch allowing the pass-through minimum level to be changed at runtime.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+        /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
         /// <param name="bufferBaseFilename"><see cref="ElasticsearchSinkOptions.BufferBaseFilename"/></param>
         /// <param name="bufferFileSizeLimitBytes"><see cref="ElasticsearchSinkOptions.BufferFileSizeLimitBytes"/></param>
         /// <param name="bufferLogShippingInterval"><see cref="ElasticsearchSinkOptions.BufferLogShippingInterval"/></param>
@@ -95,7 +95,7 @@ namespace Serilog
             long? bufferFileSizeLimitBytes = null,
             long bufferLogShippingInterval = 5000,
             string connectionGlobalHeaders = null,
-            LoggingLevelSwitch loggingLevelSwitch = null)
+            LoggingLevelSwitch levelSwitch = null)
         {
             if (string.IsNullOrEmpty(nodeUris))
                 throw new ArgumentNullException("nodeUris", "No Elasticsearch node(s) specified.");
@@ -126,7 +126,7 @@ namespace Serilog
             options.Period = TimeSpan.FromSeconds(period);
             options.InlineFields = inlineFields;
             options.MinimumLogEventLevel = restrictedToMinimumLevel;            
-            options.LoggingLevelSwitch = loggingLevelSwitch;
+            options.LevelSwitch = levelSwitch;
 
             if (!string.IsNullOrWhiteSpace(bufferBaseFilename))
             {

--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -55,7 +55,11 @@ namespace Serilog
                 ? (ILogEventSink)new ElasticsearchSink(options)
                 : new DurableElasticsearchSink(options);
 
-            return loggerSinkConfiguration.Sink(sink, options.MinimumLogEventLevel ?? LevelAlias.Minimum);
+            return loggerSinkConfiguration.Sink(
+                sink,
+                restrictedToMinimumLevel : options.MinimumLogEventLevel ?? LevelAlias.Minimum,
+                levelSwitch : options.LoggingLevelSwitch
+            );
         }
 
         /// <summary>
@@ -69,7 +73,8 @@ namespace Serilog
         /// <param name="batchPostingLimit"><see cref="ElasticsearchSinkOptions.BatchPostingLimit"/></param>
         /// <param name="period"><see cref="ElasticsearchSinkOptions.Period"/></param>
         /// <param name="inlineFields"><see cref="ElasticsearchSinkOptions.InlineFields"/></param>
-        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink. Ignored when <paramref name="loggingLevelSwitch"/> is specified.</param>
+        /// <param name="loggingLevelSwitch" > A switch allowing the pass-through minimum level to be changed at runtime.</param>
         /// <param name="bufferBaseFilename"><see cref="ElasticsearchSinkOptions.BufferBaseFilename"/></param>
         /// <param name="bufferFileSizeLimitBytes"><see cref="ElasticsearchSinkOptions.BufferFileSizeLimitBytes"/></param>
         /// <param name="bufferLogShippingInterval"><see cref="ElasticsearchSinkOptions.BufferLogShippingInterval"/></param>
@@ -89,7 +94,8 @@ namespace Serilog
             string bufferBaseFilename = null,
             long? bufferFileSizeLimitBytes = null,
             long bufferLogShippingInterval = 5000,
-            string connectionGlobalHeaders = null)
+            string connectionGlobalHeaders = null,
+            LoggingLevelSwitch loggingLevelSwitch = null)
         {
             if (string.IsNullOrEmpty(nodeUris))
                 throw new ArgumentNullException("nodeUris", "No Elasticsearch node(s) specified.");
@@ -119,7 +125,8 @@ namespace Serilog
             options.BatchPostingLimit = batchPostingLimit;
             options.Period = TimeSpan.FromSeconds(period);
             options.InlineFields = inlineFields;
-            options.MinimumLogEventLevel = restrictedToMinimumLevel;
+            options.MinimumLogEventLevel = restrictedToMinimumLevel;            
+            options.LoggingLevelSwitch = loggingLevelSwitch;
 
             if (!string.IsNullOrWhiteSpace(bufferBaseFilename))
             {

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -128,9 +128,14 @@ namespace Serilog.Sinks.Elasticsearch
         public bool InlineFields { get; set; }
 
         /// <summary>
-        /// The minimum log event level required in order to write an event to the sink.
+        /// The minimum log event level required in order to write an event to the sink. Ignored when LoggingLevelSwitch is specified.
         /// </summary>
         public LogEventLevel? MinimumLogEventLevel { get; set; }
+
+        /// <summary>
+        /// A switch allowing the pass-through minimum level to be changed at runtime.
+        /// </summary>
+        public LoggingLevelSwitch LoggingLevelSwitch { get; set; }
 
         ///<summary>
         /// When passing a serializer unknown object will be serialized to object instead of relying on their ToString representation

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -135,7 +135,7 @@ namespace Serilog.Sinks.Elasticsearch
         /// <summary>
         /// A switch allowing the pass-through minimum level to be changed at runtime.
         /// </summary>
-        public LoggingLevelSwitch LoggingLevelSwitch { get; set; }
+        public LoggingLevelSwitch LevelSwitch { get; set; }
 
         ///<summary>
         /// When passing a serializer unknown object will be serialized to object instead of relying on their ToString representation


### PR DESCRIPTION
**What issue does this PR address?**
Allows the sink to be passed a `LoggingLevelSwitch` object as an alternative to a plain minimum log level. See #138.

**Does this PR introduce a breaking change?**
No. The switch is the last argument in the public method in which it appears.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

I don't think unit tests would be appropriate here since all the code is in Serilog itself, the PR simply passes in an extra argument. 

I've tested it manually and the switches operate correctly as expected (open two ES sinks, pass different switches, set different minimum levels, log only goes to one).

