### PR TITLE
Fix field index option for 6.1+ template to use boolean value.

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchTemplateProvider.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchTemplateProvider.cs
@@ -114,7 +114,7 @@ namespace Serilog.Sinks.Elasticsearch
                         },
                         properties = new Dictionary<string, object>
                         {
-                            {"message", new {type = "text", index = "analyzed"}},
+                            {"message", new {type = "text", index = "true"}},
                             {
                                 "exceptions", new
                                 {
@@ -124,8 +124,8 @@ namespace Serilog.Sinks.Elasticsearch
                                         {"Depth", new {type = "integer"}},
                                         {"RemoteStackIndex", new {type = "integer"}},
                                         {"HResult", new {type = "integer"}},
-                                        {"StackTraceString", new {type = "text", index = "analyzed"}},
-                                        {"RemoteStackTraceString", new {type = "text", index = "analyzed"}},
+                                        {"StackTraceString", new {type = "text", index = "true"}},
+                                        {"RemoteStackTraceString", new {type = "text", index = "true"}},
                                         {
                                             "ExceptionMessage", new
                                             {

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Templating/template_v6.json
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Templating/template_v6.json
@@ -39,7 +39,7 @@
             "properties": {
                 "message": {
                     "type": "text",
-                    "index": "analyzed"
+                    "index": "true"
                 },
                 "exceptions": {
                     "type": "nested",
@@ -55,11 +55,11 @@
                         },
                         "StackTraceString": {
                             "type": "text",
-                            "index": "analyzed"
+                            "index": "true"
                         },
                         "RemoteStackTraceString": {
                             "type": "text",
-                            "index": "analyzed"
+                            "index": "true"
                         },
                         "ExceptionMessage": {
                             "type": "object",


### PR DESCRIPTION
**What issue does this PR address?**
#140 - issue in 6.1, where value for index in index template must be a boolean. 

**Does this PR introduce a breaking change?**
No, not with the new template option to specify ES version. Change only impacts 6.x template.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)
Changed: ShouldRegisterTheCorrectTemplateOnRegistration 
**Other information**:
