### PR TITLE
Updated to elasticsearch 6 libraries

### DIFF
--- a/sample/Serilog.Sinks.Elasticsearch.Sample/Serilog.Sinks.Elasticsearch.Sample.csproj
+++ b/sample/Serilog.Sinks.Elasticsearch.Sample/Serilog.Sinks.Elasticsearch.Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog" Version="2.6.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 

--- a/src/Serilog.Sinks.Elasticsearch/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Properties/AssemblyInfo.cs
@@ -3,13 +3,13 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Serilog.Sinks.Elasticsearch")]
 [assembly: AssemblyDescription("Serilog sink for Elasticsearch")]
-[assembly: AssemblyCopyright("Copyright © Serilog Contributors 2017")]
+[assembly: AssemblyCopyright("Copyright © Serilog Contributors 2018")]
 
 [assembly: InternalsVisibleTo("Serilog.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +
                                                        "6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9" +
                                                        "d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b818" +
                                                        "94191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066" +
                                                        "b19485ec")]
-[assembly: AssemblyVersion("5.3.0.0")]
-[assembly: AssemblyInformationalVersion("5.3.0-unstable.32+Branch.dev.Sha.7e77498e8afaaec96b508de3e8ec6bd3891b3556")]
-[assembly: AssemblyFileVersion("5.3.0.0")]
+[assembly: AssemblyVersion("6.0.0.0")]
+[assembly: AssemblyInformationalVersion("6.0.0-unstable.32+Branch.dev.Sha.7e77498e8afaaec96b508de3e8ec6bd3891b3556")]
+[assembly: AssemblyFileVersion("6.0.0.0")]

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.Symbols.nuspec
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.Symbols.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Serilog.Sinks.Elasticsearch</id>
-    <version>2.0.60.2</version>
+    <version>$version$</version>
     <authors>Michiel van Oudheusden, Martijn Laarman, Mogens Heller Grabe</authors>
     <description>The perfect way for .NET apps to write structured log events to Elasticsearch.</description>
     <language>en-US</language>
@@ -11,11 +11,11 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging elasticsearch</tags>
     <dependencies>
-      <dependency id="Serilog" version="2.4.0" />
-      <dependency id="Elasticsearch.Net" version="5.4.0" />
-      <dependency id="Serilog.Sinks.File" version="3.2.0" />
-      <dependency id="Serilog.Sinks.PeriodicBatching" version="2.1.0" />
-      <dependency id="Serilog.Sinks.RollingFile" version="3.3.0" />
+       <dependency id="Serilog" version="2.6.0" />
+       <dependency id="Elasticsearch.Net" version="6.0.0" />
+       <dependency id="Serilog.Sinks.File" version="4.0.0" />
+       <dependency id="Serilog.Sinks.PeriodicBatching" version="2.1.1" />
+       <dependency id="Serilog.Sinks.RollingFile" version="3.3.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.nuspec
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.ElasticSearch.nuspec
@@ -11,10 +11,10 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging elasticsearch</tags>
     <dependencies>
-      <dependency id="Serilog" version="2.4.0" />
-      <dependency id="Elasticsearch.Net" version="5.4.0" />
-      <dependency id="Serilog.Sinks.File" version="3.2.0" />
-      <dependency id="Serilog.Sinks.PeriodicBatching" version="2.1.0" />
+      <dependency id="Serilog" version="2.6.0" />
+      <dependency id="Elasticsearch.Net" version="6.0.0" />
+      <dependency id="Serilog.Sinks.File" version="4.0.0" />
+      <dependency id="Serilog.Sinks.PeriodicBatching" version="2.1.1" />
       <dependency id="Serilog.Sinks.RollingFile" version="3.3.0" />
     </dependencies>
   </metadata>

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>5.1.0</VersionPrefix>
+    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionSuffix>alpha</VersionSuffix>
     <Authors>Michiel van Oudheusden, Martijn Laarman, Mogens Heller Grabe, Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -23,12 +24,11 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <Version>5.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elasticsearch.Net" Version="5.5.0" />
-    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Elasticsearch.Net" Version="6.0.0" />
+    <PackageReference Include="Serilog" Version="2.6.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchLogShipper.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchLogShipper.cs
@@ -201,7 +201,7 @@ namespace Serilog.Sinks.Elasticsearch
                         if (count > 0)
                         {
 
-                            var response = _state.Client.Bulk<DynamicResponse>(payload);
+                            var response = _state.Client.Bulk<DynamicResponse>(PostData.MultiJson(payload));
 
                             if (response.Success)
                             {
@@ -261,7 +261,7 @@ namespace Serilog.Sinks.Elasticsearch
             }
         }
 
-        static void HandleBulkResponse(ElasticsearchResponse<DynamicResponse> response, List<string> payload)
+        static void HandleBulkResponse(DynamicResponse response, List<string> payload)
         {
             int i = 0;
             var items = response.Body["items"];

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Discrepancies/ElasticsearchDefaultSerializerTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Discrepancies/ElasticsearchDefaultSerializerTests.cs
@@ -5,7 +5,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests.Discrepancies
 {
     public class ElasticsearchDefaultSerializerTests : ElasticsearchSinkUniformityTestsBase
     {
-        public ElasticsearchDefaultSerializerTests() : base(new ElasticsearchDefaultSerializer()) { }
+        public ElasticsearchDefaultSerializerTests() : base(new LowLevelRequestResponseSerializer()) { }
 
         [Fact]
         public void Should_SerializeToExpandedExceptionObjectWhenExceptionIsSet()

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Discrepancies/JsonNetSerializerTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Discrepancies/JsonNetSerializerTests.cs
@@ -1,12 +1,13 @@
 ﻿using Elasticsearch.Net;
 using Nest;
+using Nest.JsonNetSerializer;
 using Xunit;
 
 namespace Serilog.Sinks.Elasticsearch.Tests.Discrepancies
 {
     public class JsonNetSerializerTests : ElasticsearchSinkUniformityTestsBase
     {
-        public JsonNetSerializerTests() : base(new JsonNetSerializer(new ConnectionSettings())) { }
+        public JsonNetSerializerTests() : base(JsonNetSerializer.Default(LowLevelRequestResponseSerializer.Instance, new ConnectionSettings())) { }
 
         [Fact]
         public void Should_SerializeToExpandedExceptionObjectWhenExceptionIsSet()

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
@@ -38,14 +38,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elasticsearch.Net" Version="5.5.0" />
+    <PackageReference Include="Elasticsearch.Net" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.1" />
+    <PackageReference Include="NEST.JsonNetSerializer" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="dotnet-test-nunit" Version="3.4.0-beta-3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="NEST" Version="5.5.0" />
+    <PackageReference Include="NEST" Version="6.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.2" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
   </ItemGroup>


### PR DESCRIPTION
**What issue does this PR address?**
#152 
Allows the use of serilog-sinks-elasticsearch in projects that use NEST 6 and elasticseatch-net 6

**Does this PR introduce a breaking change?**
yes; not directly but transitively because elasticsearch-net v6 has breaking changes from v5.x

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
