### PR TITLE
Explain use of `AutoRegisterTemplateVersion` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Register the sink in code or using the appSettings reader (from v2.0.42+) as sho
 var loggerConfig = new LoggerConfiguration()
     .WriteTo.Elasticsearch(new ElasticsearchSinkOptions(new Uri("http://localhost:9200") ){
              AutoRegisterTemplate = true,
+             AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv6
      });
 ```
 
@@ -165,7 +166,9 @@ Since version 5.5 you can use the RegisterTemplateFailure option. Set it to one 
  
 ### Breaking changes for version 6
 
-Starting from version 6, the sink has been upgraded to work with Elasticsearch 6.0 and has support for the new templates used by ES 6.
+Starting from version 6, the sink has been upgraded to work with Elasticsearch 6.0 and has support for the new templates used by ES 6. 
+
+If you use the `AutoRegisterTemplate` option, you need to set the `AutoRegisterTemplateVersion` option to `ESv6` in order to generate default templates that are compatible with the breaking changes in ES 6.
 
 ### Breaking changes for version 4
 


### PR DESCRIPTION
It took me a while to figure out that the reason the sink failed to start with a somewhat cryptic "Failed to execute" error was that, while I had updated all libraries to ES6-compatibile versions, I had not set the  `AutoRegisterTemplateVersion` option and so the template sent was not ES6-compatible (it used "string").

This PR explains this snag in the readme.

Note: for a future PR, would it make sense to deprecate the manual option and automatically detect the ES version when attempting to register a template? It can be fetched by a GET request at the root URL, which returns:

```    {
      "name" : "8hV7EYy",
      "cluster_name" : "docker-cluster",
      "cluster_uuid" : "bC1bTjVuTiyWoaprIIZIIw",
      "version" : {
        "number" : "6.2.1",
        "build_hash" : "7299dc3",
        "build_date" : "2018-02-07T19:34:26.990113Z",
        "build_snapshot" : false,
        "lucene_version" : "7.2.1",
        "minimum_wire_compatibility_version" : "5.6.0",
        "minimum_index_compatibility_version" : "5.0.0"
      },
      "tagline" : "You Know, for Search"
    }
```
