### PR TITLE
feature: add option to skip sending oversized data to Elasticsearch

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -131,142 +131,6 @@ namespace Serilog
         /// <param name="registerTemplateFailure"><see cref="ElasticsearchSinkOptions.RegisterTemplateFailure"/>Specifies the option on how to handle failures when writing the template to Elasticsearch. This is only applicable when using the AutoRegisterTemplate option.</param>  
         /// <param name="deadLetterIndexName"><see cref="ElasticsearchSinkOptions.DeadLetterIndexName"/>Optionally set this value to the name of the index that should be used when the template cannot be written to ES.</param>  
         /// <param name="numberOfShards"><see cref="ElasticsearchSinkOptions.NumberOfShards"/>The default number of shards.</param>   
-        /// <param name="numberOfReplicas"><see cref="ElasticsearchSinkOptions.NumberOfReplicas"/>The default number of replicas.</param>   
-        /// <returns>LoggerConfiguration object</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="nodeUris"/> is <see langword="null" />.</exception>
-        public static LoggerConfiguration Elasticsearch(
-            this LoggerSinkConfiguration loggerSinkConfiguration,
-            string nodeUris,
-            string indexFormat = null,
-            string templateName = null,
-            string typeName = "logevent",
-            int batchPostingLimit = 50,
-            int period = 2,
-            bool inlineFields = false,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            string bufferBaseFilename = null,
-            long? bufferFileSizeLimitBytes = null,
-            long bufferLogShippingInterval = 5000,
-            string connectionGlobalHeaders = null,
-            LoggingLevelSwitch levelSwitch = null,
-            int connectionTimeout = 5,
-            EmitEventFailureHandling emitEventFailure = EmitEventFailureHandling.WriteToSelfLog,
-            int queueSizeLimit = 100000,
-            string pipelineName = null,
-            bool autoRegisterTemplate = false,
-            AutoRegisterTemplateVersion autoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv2,
-            bool overwriteTemplate = false,
-            RegisterTemplateRecovery registerTemplateFailure = RegisterTemplateRecovery.IndexAnyway,
-            string deadLetterIndexName = null,
-            int? numberOfShards = null,
-            int? numberOfReplicas = null)
-        {
-            if (string.IsNullOrEmpty(nodeUris))
-                throw new ArgumentNullException(nameof(nodeUris), "No Elasticsearch node(s) specified.");
-
-            IEnumerable<Uri> nodes = nodeUris
-                .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(uriString => new Uri(uriString));
-
-            var options = new ElasticsearchSinkOptions(nodes);
-
-            if (!string.IsNullOrWhiteSpace(indexFormat))
-            {
-                options.IndexFormat = indexFormat;
-            }
-
-            if (!string.IsNullOrWhiteSpace(templateName))
-            {
-                options.AutoRegisterTemplate = true;
-                options.TemplateName = templateName;
-            }
-
-            if (!string.IsNullOrWhiteSpace(typeName))
-            {
-                options.TypeName = typeName;
-            }
-
-            options.BatchPostingLimit = batchPostingLimit;
-            options.Period = TimeSpan.FromSeconds(period);
-            options.InlineFields = inlineFields;
-            options.MinimumLogEventLevel = restrictedToMinimumLevel;            
-            options.LevelSwitch = levelSwitch;
-
-            if (!string.IsNullOrWhiteSpace(bufferBaseFilename))
-            {
-                Path.GetFullPath(bufferBaseFilename);       // validate path
-                options.BufferBaseFilename = bufferBaseFilename;
-            }
-
-            if (bufferFileSizeLimitBytes.HasValue)
-            {
-                options.BufferFileSizeLimitBytes = bufferFileSizeLimitBytes.Value;
-            }
-
-            options.BufferLogShippingInterval = TimeSpan.FromMilliseconds(bufferLogShippingInterval);
-
-            if (!string.IsNullOrWhiteSpace(connectionGlobalHeaders))
-            {
-                NameValueCollection headers = new NameValueCollection();
-                connectionGlobalHeaders
-                    .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries)
-                    .ToList()
-                    .ForEach(headerValueStr =>
-                    {
-                        var headerValue = headerValueStr.Split(new[] { '=' }, 2, StringSplitOptions.RemoveEmptyEntries);
-                        headers.Add(headerValue[0], headerValue[1]);
-                    });
-
-                options.ModifyConnectionSettings = (c) => c.GlobalHeaders(headers);
-            }
-
-            options.ConnectionTimeout = TimeSpan.FromSeconds(connectionTimeout);
-            options.EmitEventFailure = emitEventFailure;
-            options.QueueSizeLimit = queueSizeLimit;
-            options.PipelineName = pipelineName;
-
-            options.AutoRegisterTemplate = autoRegisterTemplate;
-            options.AutoRegisterTemplateVersion = autoRegisterTemplateVersion;
-            options.RegisterTemplateFailure = registerTemplateFailure;
-            options.OverwriteTemplate = overwriteTemplate;
-            options.NumberOfShards = numberOfShards;
-            options.NumberOfReplicas = numberOfReplicas;
-
-            if (!string.IsNullOrWhiteSpace(deadLetterIndexName))
-            {
-                options.DeadLetterIndexName = deadLetterIndexName;
-            }
-
-            return Elasticsearch(loggerSinkConfiguration, options);
-        }
-
-        /// <summary>
-        /// Overload to allow basic configuration through AppSettings.
-        /// </summary>
-        /// <param name="loggerSinkConfiguration">Options for the sink.</param>
-        /// <param name="nodeUris">A comma or semi column separated list of URIs for Elasticsearch nodes.</param>
-        /// <param name="indexFormat"><see cref="ElasticsearchSinkOptions.IndexFormat"/></param>
-        /// <param name="templateName"><see cref="ElasticsearchSinkOptions.TemplateName"/></param>
-        /// <param name="typeName"><see cref="ElasticsearchSinkOptions.TypeName"/></param>
-        /// <param name="batchPostingLimit"><see cref="ElasticsearchSinkOptions.BatchPostingLimit"/></param>
-        /// <param name="period"><see cref="ElasticsearchSinkOptions.Period"/></param>
-        /// <param name="inlineFields"><see cref="ElasticsearchSinkOptions.InlineFields"/></param>
-        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
-        /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
-        /// <param name="bufferBaseFilename"><see cref="ElasticsearchSinkOptions.BufferBaseFilename"/></param>
-        /// <param name="bufferFileSizeLimitBytes"><see cref="ElasticsearchSinkOptions.BufferFileSizeLimitBytes"/></param>
-        /// <param name="bufferLogShippingInterval"><see cref="ElasticsearchSinkOptions.BufferLogShippingInterval"/></param>
-        /// <param name="connectionGlobalHeaders">A comma or semi column separated list of key value pairs of headers to be added to each elastic http request</param>   
-        /// <param name="connectionTimeout"><see cref="ElasticsearchSinkOptions.ConnectionTimeout"/>The connection timeout (in seconds) when sending bulk operations to elasticsearch (defaults to 5).</param>   
-        /// <param name="emitEventFailure"><see cref="ElasticsearchSinkOptions.EmitEventFailure"/>Specifies how failing emits should be handled.</param>  
-        /// <param name="queueSizeLimit"><see cref="ElasticsearchSinkOptions.QueueSizeLimit"/>The maximum number of events that will be held in-memory while waiting to ship them to Elasticsearch. Beyond this limit, events will be dropped. The default is 100,000. Has no effect on durable log shipping.</param>   
-        /// <param name="pipelineName"><see cref="ElasticsearchSinkOptions.PipelineName"/>Name the Pipeline where log events are sent to sink. Please note that the Pipeline should be existing before the usage starts.</param>   
-        /// <param name="autoRegisterTemplate"><see cref="ElasticsearchSinkOptions.AutoRegisterTemplate"/>When set to true the sink will register an index template for the logs in elasticsearch.</param>   
-        /// <param name="autoRegisterTemplateVersion"><see cref="ElasticsearchSinkOptions.AutoRegisterTemplateVersion"/>When using the AutoRegisterTemplate feature, this allows to set the Elasticsearch version. Depending on the version, a template will be selected. Defaults to pre 5.0.</param>  
-        /// <param name="overwriteTemplate"><see cref="ElasticsearchSinkOptions.OverwriteTemplate"/>When using the AutoRegisterTemplate feature, this allows you to overwrite the template in Elasticsearch if it already exists. Defaults to false</param>   
-        /// <param name="registerTemplateFailure"><see cref="ElasticsearchSinkOptions.RegisterTemplateFailure"/>Specifies the option on how to handle failures when writing the template to Elasticsearch. This is only applicable when using the AutoRegisterTemplate option.</param>  
-        /// <param name="deadLetterIndexName"><see cref="ElasticsearchSinkOptions.DeadLetterIndexName"/>Optionally set this value to the name of the index that should be used when the template cannot be written to ES.</param>  
-        /// <param name="numberOfShards"><see cref="ElasticsearchSinkOptions.NumberOfShards"/>The default number of shards.</param>   
         /// <param name="numberOfReplicas"><see cref="ElasticsearchSinkOptions.NumberOfReplicas"/>The default number of replicas.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="connection">Allows you to override the connection used to communicate with elasticsearch.</param>
@@ -275,6 +139,7 @@ namespace Serilog
         /// <param name="customFormatter">Customizes the formatter used when converting log events into ElasticSearch documents. Please note that the formatter output must be valid JSON :)</param>
         /// <param name="customDurableFormatter">Customizes the formatter used when converting log events into the durable sink. Please note that the formatter output must be valid JSON :)</param>
         /// <param name="failureSink">Sink to use when Elasticsearch is unable to accept the events. This is optionally and depends on the EmitEventFailure setting.</param>   
+        /// <param name="singleEventSizePostingLimit"><see cref="ElasticsearchSinkOptions.SingleEventSizePostingLimit"/>The maximum length of an event allowed to be posted to Elasticsearch.</param>        
         /// <returns>LoggerConfiguration object</returns>
         /// <exception cref="ArgumentNullException"><paramref name="nodeUris"/> is <see langword="null" />.</exception>
         public static LoggerConfiguration Elasticsearch(
@@ -309,7 +174,8 @@ namespace Serilog
             IConnectionPool connectionPool = null,
             ITextFormatter customFormatter = null,
             ITextFormatter customDurableFormatter = null,
-            ILogEventSink failureSink = null)
+            ILogEventSink failureSink = null,
+            int singleEventSizePostingLimit = 0)
         {
             if (string.IsNullOrEmpty(nodeUris))
                 throw new ArgumentNullException(nameof(nodeUris), "No Elasticsearch node(s) specified.");
@@ -337,6 +203,7 @@ namespace Serilog
             }
 
             options.BatchPostingLimit = batchPostingLimit;
+            options.SingleEventSizePostingLimit = singleEventSizePostingLimit;
             options.Period = TimeSpan.FromSeconds(period);
             options.InlineFields = inlineFields;
             options.MinimumLogEventLevel = restrictedToMinimumLevel;

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -114,6 +114,11 @@ namespace Serilog.Sinks.Elasticsearch
         public int BatchPostingLimit { get; set; }
 
         ///<summary>
+        /// The maximum length of a an event record to be sent. Defaults to: 0 (No Limit)
+        /// </summary>
+        public int SingleEventSizePostingLimit { get; set; }
+
+        ///<summary>
         /// The time to wait between checking for event batches. Defaults to 2 seconds.
         /// </summary>
         public TimeSpan Period { get; set; }
@@ -230,6 +235,7 @@ namespace Serilog.Sinks.Elasticsearch
             this.TypeName = "logevent";
             this.Period = TimeSpan.FromSeconds(2);
             this.BatchPostingLimit = 50;
+            this.SingleEventSizePostingLimit = 0;
             this.TemplateName = "serilog-events-template";
             this.ConnectionTimeout = TimeSpan.FromSeconds(5);
             this.EmitEventFailure = EmitEventFailureHandling.WriteToSelfLog;

--- a/test/Serilog.Sinks.Elasticsearch.Tests/ElasticSearchLogShipperTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/ElasticSearchLogShipperTests.cs
@@ -1,14 +1,14 @@
-﻿using System;
+﻿using Serilog.Debugging;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Serilog.Sinks.Elasticsearch.Tests
 {
-    public class ElasticSearchLogShipperTests
+    public class ElasticSearchLogShipperTests : ElasticsearchSinkTestsBase
     {
         //To enable tests :
         // * Create public key token for Testproject, make Serilog.Sinks.Elasticsearch internals visible to testproject & scope ElasticsearchLogShipper to internal.
@@ -32,7 +32,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests
         //        string nextLine;
         //        long nextStart = 0;
 
-        //        ElasticsearchLogShipper.TryReadLine(s,ref nextStart, out nextLine);
+        //        ElasticsearchLogShipper.TryReadLine(s, ref nextStart, out nextLine);
 
         //        Assert.Equal(Encoding.UTF8.GetByteCount(testLine1) + +Encoding.UTF8.GetByteCount(Environment.NewLine) + 3, nextStart);
         //        Assert.Equal(testLine1, nextLine);
@@ -69,6 +69,35 @@ namespace Serilog.Sinks.Elasticsearch.Tests
         //        ElasticsearchLogShipper.TryReadLine(s, ref nextStart, out nextLine);
         //        Assert.Equal(testLine2, nextLine);
 
+        //    }
+        //}
+
+        //[Fact]
+        //public void ElasticsearchLogShipper_CreatePayLoad_ShouldSkipOversizedEvent()
+        //{
+        //    var selfLogMessages = new StringBuilder();
+        //    SelfLog.Enable(new StringWriter(selfLogMessages));
+        //    string testLine1 = "test 1";
+        //    string testLine2 = "test 2";
+        //    string testLine3 = "1234567";
+        //    var startPosition = 0;
+        //    _options.BatchPostingLimit = 50;
+        //    _options.SingleEventSizePostingLimit = 6;
+
+        //    var payLoad = new List<string>();
+        //    using (MemoryStream s = new MemoryStream())
+        //    using (StreamWriter sw = new StreamWriter(s, new UTF8Encoding(false)))
+        //    {
+        //        sw.WriteLine(testLine1);
+        //        sw.WriteLine(testLine2);
+        //        sw.WriteLine(testLine3);
+        //        sw.Flush();
+
+        //        (new ElasticsearchLogShipper(_options)).CreatePayLoad(s, payLoad, "TestIndex", startPosition, "D:\\TestFile");
+
+        //        var expectedNumberOfLines = 2;
+        //        Assert.Equal(expectedNumberOfLines*2, payLoad.Count());
+        //        Assert.Contains("Skip sending to ElasticSearch", selfLogMessages.ToString());
         //    }
         //}
     }


### PR DESCRIPTION
**What issue does this PR address?**
- For enhancement request #166

**Does this PR introduce a breaking change?**
- No

**Other information**:
- New option : SingleEventSizePostingLimit (default to 0: no limit)
- Remove redundant overload method in LoggerConfigurationElasticSearchExtensions.cs