### PR TITLE
New NuGet API Key

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: nvZ/z+pMS91b3kG4DgfES5AcmwwGoBYQxr9kp4XiJHj25SAlgdIxFx++1N0lFH2x
+    secure: bd9z4P73oltOXudAjPehwp9iDKsPtC+HbgshOrSgoyQKr5xVK+bxJQngrDJkHdY8
   on:
     branch: /^(master|dev)$/
 install:


### PR DESCRIPTION
**What issue does this PR address?**

Post moving to NuGet orgs (see #1159) a new key is needed to push packages.  Current [builds](https://ci.appveyor.com/project/serilog/serilog/build/977) are failing.

The API key has been created under the Serilog org in NuGet.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)