### PR TITLE
Changed FailureSink from FileSink(deprecated) to RollingFileSink

### DIFF
--- a/sample/Serilog.Sinks.Elasticsearch.Sample/Program.cs
+++ b/sample/Serilog.Sinks.Elasticsearch.Sample/Program.cs
@@ -2,7 +2,7 @@
 using Serilog;
 using Serilog.Debugging;
 using Serilog.Formatting.Json;
-using Serilog.Sinks.File;
+using Serilog.Sinks.RollingFile;
 using Serilog.Sinks.SystemConsole.Themes;
 
 namespace Serilog.Sinks.Elasticsearch.Sample
@@ -23,7 +23,7 @@ namespace Serilog.Sinks.Elasticsearch.Sample
                     EmitEventFailure = EmitEventFailureHandling.WriteToSelfLog |
                                        EmitEventFailureHandling.WriteToFailureSink |
                                        EmitEventFailureHandling.RaiseCallback,
-                    FailureSink = new FileSink("./failures.txt", new JsonFormatter(), null)
+                    FailureSink = new RollingFileSink("./fail-{Date}.txt", new JsonFormatter(), null, null)
                 })
                 .CreateLogger();
 


### PR DESCRIPTION
**What issue does this PR address?**
FileSink() is deprecated and the example text generates a warning message.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
