### PR TITLE
added BufferFileCountLimit to limit number of files

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -119,6 +119,7 @@ namespace Serilog
         /// <param name="levelSwitch">A switch allowing the pass-through minimum level to be changed at runtime.</param>
         /// <param name="bufferBaseFilename"><see cref="ElasticsearchSinkOptions.BufferBaseFilename"/></param>
         /// <param name="bufferFileSizeLimitBytes"><see cref="ElasticsearchSinkOptions.BufferFileSizeLimitBytes"/></param>
+        /// <param name="bufferFileCountLimit"><see cref="ElasticsearchSinkOptions.BufferFileCountLimit"/></param>        
         /// <param name="bufferLogShippingInterval"><see cref="ElasticsearchSinkOptions.BufferLogShippingInterval"/></param>
         /// <param name="connectionGlobalHeaders">A comma or semi column separated list of key value pairs of headers to be added to each elastic http request</param>   
         /// <param name="connectionTimeout"><see cref="ElasticsearchSinkOptions.ConnectionTimeout"/>The connection timeout (in seconds) when sending bulk operations to elasticsearch (defaults to 5).</param>   
@@ -153,7 +154,7 @@ namespace Serilog
             bool inlineFields = false,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             string bufferBaseFilename = null,
-            long? bufferFileSizeLimitBytes = null,
+            long? bufferFileSizeLimitBytes = null,            
             long bufferLogShippingInterval = 5000,
             string connectionGlobalHeaders = null,
             LoggingLevelSwitch levelSwitch = null,
@@ -175,7 +176,8 @@ namespace Serilog
             ITextFormatter customFormatter = null,
             ITextFormatter customDurableFormatter = null,
             ILogEventSink failureSink = null,
-            int singleEventSizePostingLimit = 0)
+            int singleEventSizePostingLimit = 0,
+            int? bufferFileCountLimit = null)
         {
             if (string.IsNullOrEmpty(nodeUris))
                 throw new ArgumentNullException(nameof(nodeUris), "No Elasticsearch node(s) specified.");
@@ -220,6 +222,10 @@ namespace Serilog
                 options.BufferFileSizeLimitBytes = bufferFileSizeLimitBytes.Value;
             }
 
+            if (bufferFileCountLimit.HasValue)
+            {
+                options.BufferFileCountLimit = bufferFileCountLimit.Value;
+            }
             options.BufferLogShippingInterval = TimeSpan.FromMilliseconds(bufferLogShippingInterval);
 
             if (!string.IsNullOrWhiteSpace(connectionGlobalHeaders))

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/DurableElasticSearchSink.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/DurableElasticSearchSink.cs
@@ -41,7 +41,7 @@ namespace Serilog.Sinks.Elasticsearch
                 options.BufferBaseFilename + FileNameSuffix,
                 _state.DurableFormatter,
                 options.BufferFileSizeLimitBytes,
-                null);
+                options.BufferFileCountLimit);
 
             _shipper = new ElasticsearchLogShipper(_state);
         }

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -224,6 +224,11 @@ namespace Serilog.Sinks.Elasticsearch
                 _queueSizeLimit = value;
             }
         }
+        /// <summary>
+        /// The maximum number of log files that will be retained,
+        /// including the current log file. For unlimited retention, pass null. The default is null.
+        /// </summary>
+        public int? BufferFileCountLimit { get; set; }
 
         /// <summary>
         /// Configures the elasticsearch sink defaults
@@ -241,6 +246,7 @@ namespace Serilog.Sinks.Elasticsearch
             this.EmitEventFailure = EmitEventFailureHandling.WriteToSelfLog;
             this.RegisterTemplateFailure = RegisterTemplateRecovery.IndexAnyway;
             this.QueueSizeLimit = 100000;
+            this.BufferFileCountLimit = null;
         }
 
         /// <summary>


### PR DESCRIPTION
option to set number of days of logfiles to keep #202

**What issue does this PR address?**
 #202 

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)
No
**Other information**:
I tried it locally with setting BufferFileCountLimit= 1 and old files was nicely removed