### PR TITLE
for ES v6 use "index_patterns" instead of "template" field

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchTemplateProvider.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchTemplateProvider.cs
@@ -58,7 +58,7 @@ namespace Serilog.Sinks.Elasticsearch
         {
             return new
             {
-                template = templateMatchString,
+                index_patterns = new[] { templateMatchString },
                 settings = settings,
                 mappings = new
                 {

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Templating/template_v6.json
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Templating/template_v6.json
@@ -1,5 +1,5 @@
 ﻿{
-    "template": "logstash-*",
+    "index_patterns": [ "logstash-*" ],
     "settings": {
         "index.refresh_interval": "5s"
     },


### PR DESCRIPTION
**What issue does this PR address?**
fixes #206 

**Does this PR introduce a breaking change?**
afaict NO

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
This only fixes the error, a follow-up deprecation warning `#! Deprecation: [_default_] mapping is deprecated since it is not useful anymore now that indexes cannot have more than one type` is not addressed.