### PR TITLE
add .netstandard2.0 target

### DIFF
--- a/src/Serilog.Formatting.Elasticsearch/Serilog.Formatting.Elasticsearch.csproj
+++ b/src/Serilog.Formatting.Elasticsearch/Serilog.Formatting.Elasticsearch.csproj
@@ -37,7 +37,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);NO_SERIALIZATION</DefineConstants>
   </PropertyGroup>
-    
+
   <ItemGroup>
     <DotNetCliToolReference Include="dotnet-version" Version="1.1.0" />
   </ItemGroup>

--- a/src/Serilog.Formatting.Elasticsearch/Serilog.Formatting.Elasticsearch.csproj
+++ b/src/Serilog.Formatting.Elasticsearch/Serilog.Formatting.Elasticsearch.csproj
@@ -4,7 +4,7 @@
     <VersionPrefix>6.0.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <Authors>Michiel van Oudheusden, Martijn Laarman, Mogens Heller Grabe, Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Formatting.Elasticsearch</AssemblyName>
@@ -35,9 +35,9 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <DefineConstants>$(DefineConstants);DOTNETCORE;NO_SERIALIZATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);NO_SERIALIZATION</DefineConstants>
   </PropertyGroup>
-
+    
   <ItemGroup>
     <DotNetCliToolReference Include="dotnet-version" Version="1.1.0" />
   </ItemGroup>

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -4,7 +4,7 @@
     <VersionPrefix>6.0.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
     <Authors>Michiel van Oudheusden, Martijn Laarman, Mogens Heller Grabe, Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Elasticsearch</AssemblyName>
@@ -45,19 +45,19 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-        <NoWarn>1591;1701;1702</NoWarn>
-        <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER</DefineConstants>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-        <NoWarn>1591;1701;1702</NoWarn>
-        <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;HRESULTS</DefineConstants>
-    </PropertyGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-      <NoWarn>1591;1701;1702</NoWarn>
-    <DefineConstants>$(DefineConstants);DOTNETCORE;NO_SERIALIZATION;NO_TIMER</DefineConstants>
+    <NoWarn>1591;1701;1702</NoWarn>
+    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <NoWarn>1591;1701;1702</NoWarn>
+    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <NoWarn>1591;1701;1702</NoWarn>
+    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;HRESULTS</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Discrepancies/ElasticsearchSinkUniformityTestsBase.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Discrepancies/ElasticsearchSinkUniformityTestsBase.cs
@@ -54,6 +54,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests.Discrepancies
                 .And.Be(exceptionMessage);
             var realException = firstEvent.Exceptions[0];
 #if !NO_SERIALIZATION
+#if !PARTIALLY_SERIALIZATION
             realException.ExceptionMethod.Should().NotBeNull();
             realException.ExceptionMethod.Name.Should().NotBeNullOrWhiteSpace();
             realException.ExceptionMethod.AssemblyName.Should().NotBeNullOrWhiteSpace();
@@ -61,7 +62,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests.Discrepancies
             realException.ExceptionMethod.ClassName.Should().NotBeNullOrWhiteSpace();
             realException.ExceptionMethod.Signature.Should().NotBeNullOrWhiteSpace();
             realException.ExceptionMethod.MemberType.Should().BeGreaterThan(0);
-
+#endif
             var nastyException = firstEvent.Exceptions[1];
             nastyException.Depth.Should().Be(1);
             nastyException.Message.Should().Be("nasty inner exception");

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net451</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Elasticsearch.Tests</AssemblyName>
     <PackageId>Serilog.Sinks.Elasticsearch.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -64,7 +64,11 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <DefineConstants>$(DefineConstants);DOTNETCORE;NO_SERIALIZATION;NO_TIMER</DefineConstants>
+    <DefineConstants>$(DefineConstants);DOTNETCORE;NO_SERIALIZATION</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <DefineConstants>$(DefineConstants);DOTNETCORE;PARTIALLY_SERIALIZATION</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
to fix #210 and fix #196  

A few comments about changes:

* `DOTNETCORE` constant is used only in tests projects. By this reason it was removed from `Serilog.Formatting.Elasticsearch` and `Serilog.Sinks.Elasticsearch` projects
* `NO_SERIALIZATION` and `NO_TIMER` constants are not used in `Serilog.Sinks.Elasticsearch` project and was removed from `netstandard1.3` target framework
* [System.Exception.GetObjectData](https://docs.microsoft.com/en-us/dotnet/api/system.exception.getobjectdata?view=netframework-4.7.2#applies-to) is accessible in netstandard2.0, however [`ExceptionMethod` is initialized with `null` value](https://github.com/dotnet/coreclr/blob/526c32c221192cd5876239b2d72c68d1ba0c40c3/src/System.Private.CoreLib/src/System/Exception.cs#L447). So, there was introduced new compilation constant `PARTIALLY_SERIALIZATION` to handle such situation for `netstandard2.0`   