### PR TITLE
Update serilog nuget package to 2.8.0 version

### DIFF
--- a/sample/Serilog.Sinks.Elasticsearch.Sample/Serilog.Sinks.Elasticsearch.Sample.csproj
+++ b/sample/Serilog.Sinks.Elasticsearch.Sample/Serilog.Sinks.Elasticsearch.Sample.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 

--- a/src/Serilog.Formatting.Elasticsearch/Serilog.Formatting.Elasticsearch.csproj
+++ b/src/Serilog.Formatting.Elasticsearch/Serilog.Formatting.Elasticsearch.csproj
@@ -19,7 +19,7 @@
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-elasticsearch</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
@@ -31,7 +31,7 @@
     
   <ItemGroup>
     <PackageReference Include="Elasticsearch.Net" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -19,7 +19,7 @@
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/serilog/serilog-sinks-elasticsearch</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Elasticsearch.Net" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />


### PR DESCRIPTION
Update of Serilog package has two reasons:

1. Serilog 2.8.0 has separate target for .netstandard2.0;
2. Dependency graph was simplified

Serilog 2.6.0:

```plain
.NETStandard 1.3
Microsoft.CSharp (>= 4.0.1)
System.Collections (>= 4.0.11)
System.Collections.NonGeneric (>= 4.0.1)
System.Dynamic.Runtime (>= 4.0.11)
System.Globalization (>= 4.0.11)
System.Linq (>= 4.1.0)
System.Reflection (>= 4.1.0)
System.Reflection.Extensions (>= 4.0.1)
System.Runtime (>= 4.1.0)
System.Runtime.Extensions (>= 4.1.0)
System.Text.RegularExpressions (>= 4.1.0)
System.Threading (>= 4.0.11)
```

Serilog 2.8.0:

```plain
.NETStandard 1.3
NETStandard.Library (>= 1.6.1)
System.Collections.NonGeneric (>= 4.3.0)
.NETStandard 2.0
System.Collections.NonGeneric (>= 4.3.0)
```