### PR TITLE
Added FormatStackTraceAsArray option to write StackTrace as an array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,14 @@
-== Changelog
-7.0
+## Changelog
+
+7.1
  * DurableElasticsearchSink is rewritten to use the same base code as the sink for Serilog.Sinks.Seq. Nuget Serilog.Sinks.File is now used instead of deprecated Serilog.Sinks.RollingFile. Lots of new fintuning options for file storage is added in ElasticsearchSinkOptions.  Updated  Serilog.Sinks.Elasticsearch.Sample.Main with SetupLoggerWithPersistantStorage with all available options for durable mode.
  * Changed datatype on singleEventSizePostingLimit  from int to long? with default value null. to make it possible ro reuse code from Sinks.Seq .
  * IndexDecider didnt worked well in buffer mode because of LogEvent was null. Added BufferIndexDecider.
  * Added BufferCleanPayload and an example which makes it possible to cleanup your invalid logging document if rejected from elastic because of inconsistent datatype on a field. It'seasy to miss errors in the self log now its possible to se logrows which is bad for elasticsearch in the elastic log.
  * Added BufferRetainedInvalidPayloadsLimitBytes A soft limit for the number of bytes to use for storing failed requests.
  * Added BufferFileCountLimit The maximum number of log files that will be retained.
+ * Formatting has been moved to seperate package.
+
 6.4
  * Render message by default (#160). 
  * Expose interface-typed options via appsettings (#162)

--- a/GitVersion.yaml
+++ b/GitVersion.yaml
@@ -1,3 +1,0 @@
-mode: ContinuousDelivery
-next-version: 5.2.0
-branches: {}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 6.4.0
+next-version: 7.0.0
 branches: {}
 ignore:
   sha: []

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,13 @@ deploy:
     secure: bd9z4P73oltOXudAjPehwp9iDKsPtC+HbgshOrSgoyQKr5xVK+bxJQngrDJkHdY8
   on:
     branch: /^(master|dev)$/
+- provider: GitHub
+  auth_token:
+    secure: XSO0LDYd89yw5rAQ8HvAgdX7NBo1m4bEqHlj0NZxtA6zKunLwCSYoVHU+k3cvQIP
+  on:
+    branch: master
+  artifact: /Serilog.*\.nupkg/
+  tag: v$(appveyor_build_version)
 install:
   - choco install gitversion.portable -y
 assembly_info:

--- a/src/Serilog.Formatting.Elasticsearch/DefaultJsonFormatter.cs
+++ b/src/Serilog.Formatting.Elasticsearch/DefaultJsonFormatter.cs
@@ -329,6 +329,19 @@ namespace Serilog.Formatting.Elasticsearch
         }
 
         /// <summary>
+        /// Writes out a json property with an array as the value
+        /// </summary>
+        protected virtual void WriteJsonArrayProperty(string name, IEnumerable sequence, ref string precedingDelimiter, TextWriter output)
+        {
+            output.Write(precedingDelimiter);
+            output.Write("\"");
+            output.Write(name);
+            output.Write("\":");
+            WriteSequence(sequence, output);
+            precedingDelimiter = ",";
+        }
+
+        /// <summary>
         /// Allows a subclass to write out objects that have no configured literal writer.
         /// </summary>
         /// <param name="value">The value to be written as a json construct</param>

--- a/src/Serilog.Formatting.Elasticsearch/ElasticsearchJsonFormatter.cs
+++ b/src/Serilog.Formatting.Elasticsearch/ElasticsearchJsonFormatter.cs
@@ -32,6 +32,7 @@ namespace Serilog.Formatting.Elasticsearch
     {
         readonly IElasticsearchSerializer _serializer;
         readonly bool _inlineFields;
+        readonly bool _formatStackTraceAsArray;
 
         /// <summary>
         /// Render message property name
@@ -69,6 +70,7 @@ namespace Serilog.Formatting.Elasticsearch
         /// <param name="serializer">Inject a serializer to force objects to be serialized over being ToString()</param>
         /// <param name="inlineFields">When set to true values will be written at the root of the json document</param>
         /// <param name="renderMessageTemplate">If true, the message template will be rendered and written to the output as a
+        /// <param name="formatStackTraceAsArray">If true, splits the StackTrace by new line and writes it as a an array of strings</param>
         /// property named RenderedMessageTemplate.</param>
         public ElasticsearchJsonFormatter(
             bool omitEnclosingObject = false,
@@ -77,11 +79,13 @@ namespace Serilog.Formatting.Elasticsearch
             IFormatProvider formatProvider = null,
             IElasticsearchSerializer serializer = null,
             bool inlineFields = false,
-            bool renderMessageTemplate = true)
+            bool renderMessageTemplate = true,
+            bool formatStackTraceAsArray = false)
             : base(omitEnclosingObject, closingDelimiter, renderMessage, formatProvider, renderMessageTemplate)
         {
             _serializer = serializer;
             _inlineFields = inlineFields;
+            _formatStackTraceAsArray = formatStackTraceAsArray;
         }
 
         /// <summary>
@@ -219,8 +223,16 @@ namespace Serilog.Formatting.Elasticsearch
             this.WriteJsonProperty("ClassName", className, ref delim, output);
             this.WriteJsonProperty("Message", exception.Message, ref delim, output);
             this.WriteJsonProperty("Source", source, ref delim, output);
-            this.WriteJsonProperty("StackTraceString", stackTrace, ref delim, output);
-            this.WriteJsonProperty("RemoteStackTraceString", remoteStackTrace, ref delim, output);
+            if (_formatStackTraceAsArray)
+            {
+                WriteMultilineString("StackTrace", stackTrace, ref delim, output);
+                WriteMultilineString("RemoteStackTrace", stackTrace, ref delim, output);
+            }
+            else
+            {
+                this.WriteJsonProperty("StackTraceString", stackTrace, ref delim, output);
+                this.WriteJsonProperty("RemoteStackTraceString", remoteStackTrace, ref delim, output);
+            }
             this.WriteJsonProperty("RemoteStackIndex", remoteStackIndex, ref delim, output);
             this.WriteStructuredExceptionMethod(exceptionMethod, ref delim, output);
             this.WriteJsonProperty("HResult", hresult, ref delim, output);
@@ -230,7 +242,12 @@ namespace Serilog.Formatting.Elasticsearch
             //JsonNET assumes string, simplejson writes array of numerics.
             //Skip for now
             //this.WriteJsonProperty("WatsonBuckets", watsonBuckets, ref delim, output);
+        }
 
+        private void WriteMultilineString(string name, string value, ref string delimeter, TextWriter output)
+        {
+            string[] lines = value.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            WriteJsonArrayProperty(name, lines, ref delimeter, output);
         }
 
         private void WriteStructuredExceptionMethod(string exceptionMethodString, ref string delim, TextWriter output)

--- a/src/Serilog.Formatting.Elasticsearch/ElasticsearchJsonFormatter.cs
+++ b/src/Serilog.Formatting.Elasticsearch/ElasticsearchJsonFormatter.cs
@@ -225,8 +225,8 @@ namespace Serilog.Formatting.Elasticsearch
             this.WriteJsonProperty("Source", source, ref delim, output);
             if (_formatStackTraceAsArray)
             {
-                WriteMultilineString("StackTrace", stackTrace, ref delim, output);
-                WriteMultilineString("RemoteStackTrace", stackTrace, ref delim, output);
+                this.WriteMultilineString("StackTrace", stackTrace, ref delim, output);
+                this.WriteMultilineString("RemoteStackTrace", stackTrace, ref delim, output);
             }
             else
             {

--- a/src/Serilog.Formatting.Elasticsearch/ExceptionAsObjectJsonFormatter.cs
+++ b/src/Serilog.Formatting.Elasticsearch/ExceptionAsObjectJsonFormatter.cs
@@ -43,7 +43,15 @@ namespace Serilog.Formatting.Elasticsearch
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="serializer">Inject a serializer to force objects to be serialized over being ToString()</param>
         /// <param name="inlineFields">When set to true values will be written at the root of the json document</param>
-        public ExceptionAsObjectJsonFormatter(bool omitEnclosingObject = false, string closingDelimiter = null, bool renderMessage = false, IFormatProvider formatProvider = null, IElasticsearchSerializer serializer = null, bool inlineFields = false) : base(omitEnclosingObject, closingDelimiter, renderMessage, formatProvider, serializer, inlineFields)
+        /// <param name="formatStackTraceAsArray">If true, splits the StackTrace by new line and writes it as a an array of strings</param>
+        public ExceptionAsObjectJsonFormatter(bool omitEnclosingObject = false, 
+            string closingDelimiter = null, 
+            bool renderMessage = false, 
+            IFormatProvider formatProvider = null, 
+            IElasticsearchSerializer serializer = null, 
+            bool inlineFields = false, 
+            bool formatStackTraceAsArray = false) 
+            : base(omitEnclosingObject, closingDelimiter, renderMessage, formatProvider, serializer, inlineFields, formatStackTraceAsArray)
         {
         }
 

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -248,6 +248,11 @@ namespace Serilog.Sinks.Elasticsearch
         public int? BufferFileCountLimit { get; set; }
 
         /// <summary>
+        /// When set to true splits the StackTrace by new line and writes it as a an array of strings.
+        /// </summary>
+        public bool FormatStackTraceAsArray { get; set; }
+
+        /// <summary>
         /// Configures the elasticsearch sink defaults
         /// </summary>
         public ElasticsearchSinkOptions()

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -270,6 +270,7 @@ namespace Serilog.Sinks.Elasticsearch
             this.QueueSizeLimit = 100000;
             this.BufferFileCountLimit = 31;
             this.BufferFileSizeLimitBytes = 100L * 1024 * 1024;
+            this.FormatStackTraceAsArray = false;
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
@@ -94,7 +94,8 @@ namespace Serilog.Sinks.Elasticsearch
                 formatProvider: options.FormatProvider,
                 closingDelimiter: string.Empty,
                 serializer: options.Serializer,
-                inlineFields: options.InlineFields
+                inlineFields: options.InlineFields,
+                formatStackTraceAsArray: options.FormatStackTraceAsArray
             );
         }
 
@@ -104,7 +105,8 @@ namespace Serilog.Sinks.Elasticsearch
                formatProvider: options.FormatProvider,
                closingDelimiter: Environment.NewLine,
                serializer: options.Serializer,
-               inlineFields: options.InlineFields
+               inlineFields: options.InlineFields,
+               formatStackTraceAsArray: options.FormatStackTraceAsArray
            );
         }
 


### PR DESCRIPTION
**What issue does this PR address?**
This PR fixes #229

**Does this PR introduce a breaking change?**
No. The new flag is false by default, which keeps the current behavior. If the flag is set to true the new behavior takes place.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
