### PR TITLE
Fixes two problems, needing to use indexers on a dynamic, and a logic…

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchLogClient.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchLogClient.cs
@@ -35,7 +35,7 @@ namespace Serilog.Sinks.Elasticsearch.Durable
             return await SendPayloadAsync(payload, true);
         }
 
-        public async Task<SentPayloadResult> SendPayloadAsync(List<string> payload,bool first)
+        public async Task<SentPayloadResult> SendPayloadAsync(List<string> payload, bool first)
         {
             try
             {
@@ -45,10 +45,10 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                 if (response.Success)
                 {
                     var cleanPayload = new List<string>();
-                    var invalidPayload = GetInvalidPayloadAsync(response, payload,out cleanPayload);
-                    if ((cleanPayload?.Any() ?? false) && first)
+                    var invalidPayload = GetInvalidPayloadAsync(response, payload, out cleanPayload);
+                    if ((cleanPayload?.Any() == false) && first)
                     {
-                        await SendPayloadAsync(cleanPayload,false);
+                        await SendPayloadAsync(cleanPayload, false);
                     }
 
                     return new SentPayloadResult(response, true, invalidPayload);
@@ -85,7 +85,8 @@ namespace Serilog.Sinks.Elasticsearch.Durable
             bool hasErrors = false;
             foreach (dynamic item in items)
             {
-                long? status = item.index?.status;
+                var itemIndex = item?["index"];
+                long? status = itemIndex?["status"];
                 i++;
                 if (!status.HasValue || status < 300)
                 {
@@ -93,8 +94,8 @@ namespace Serilog.Sinks.Elasticsearch.Durable
                 }
 
                 hasErrors = true;
-                var id = item.index?._id;
-                var error = item.index?.error;
+                var id = itemIndex?["_id"];
+                var error = itemIndex?["error"];
                 if (int.TryParse(id.Split('_')[0], out int index))
                 {
                     SelfLog.WriteLine("Received failed ElasticSearch shipping result {0}: {1}. Failed payload : {2}.", status, error?.ToString(), payload.ElementAt(index * 2 + 1));


### PR DESCRIPTION
… error that prevented the durable log files from being processed.
This PR fixes two issues in ElasticsearchLogClient.cs.
- The first is similar to PR #264 to address the properties on a dymanic using index access instead of properties.  For some reason this property access doesn't work.
- The second is a logic error the stops the log files from being processed.
