### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This example shows the options that are currently available when using the appSe
     <add key="serilog:write-to:Elasticsearch.batchPostingLimit" value="50"/>
     <add key="serilog:write-to:Elasticsearch.period" value="2"/>
     <add key="serilog:write-to:Elasticsearch.inlineFields" value="true"/>
-    <add key="serilog:write-to:Elasticsearch.minimumLogEventLevel" value="Warning"/>
+    <add key="serilog:write-to:Elasticsearch.restrictedToMinimumLevel" value="Warning"/>
     <add key="serilog:write-to:Elasticsearch.bufferBaseFilename" value="C:\Temp\SerilogElasticBuffer"/>
     <add key="serilog:write-to:Elasticsearch.bufferFileSizeLimitBytes" value="5242880"/>
     <add key="serilog:write-to:Elasticsearch.bufferLogShippingInterval" value="5000"/>
@@ -180,7 +180,7 @@ In your `appsettings.json` file, under the `Serilog` node, :
           "batchPostingLimit": 50,
           "period": 2000,
           "inlineFields": true,
-          "minimumLogEventLevel": "Warning",
+          "restrictedToMinimumLevel": "Warning",
           "bufferBaseFilename":  "C:/Temp/LogDigipolis/docker-elk-serilog-web-buffer",
           "bufferFileSizeLimitBytes": 5242880,
           "bufferLogShippingInterval": 5000,


### PR DESCRIPTION
**What issue does this PR address?**
#278 minimumLogEventLevel setting does not work 

**Does this PR introduce a breaking change?**
No because if the wrong value was used before it wouldn't work anyway.

**Please check if the PR fulfills these requirements**
- [ x ] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)

**Other information**:
Documentation was describing a configuration value that was not used by the application. Which caused a unwanted behaviour. According to https://github.com/serilog/serilog-sinks-elasticsearch/blob/dev/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs#L96 and my tests the correct value is `restrictedToMinimumLevel`.