### PR TITLE
Fix log events not being written to Sink when exception has no stacktrace

### DIFF
--- a/src/Serilog.Formatting.Elasticsearch/ElasticsearchJsonFormatter.cs
+++ b/src/Serilog.Formatting.Elasticsearch/ElasticsearchJsonFormatter.cs
@@ -247,7 +247,7 @@ namespace Serilog.Formatting.Elasticsearch
 
         private void WriteMultilineString(string name, string value, ref string delimeter, TextWriter output)
         {
-            string[] lines = value.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            var lines = value?.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries) ?? new string[] { };
             WriteJsonArrayProperty(name, lines, ref delimeter, output);
         }
 


### PR DESCRIPTION
**What issue does this PR address?**
#281 - Log Events not Written to Sink with Inner Exceptions.

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
A null reference exception was thrown when trying to format Exception with no stacktrace (either root or inner one). This caused log events not to be written to the Sink.

This only happens, when someone tries to log an exception that wasn't thrown, but created via the `new` keyword. The latter one has most properties set to `null` because it was not thrown. While it's rare that such instance of the Exception class is used, the formatter should still be able to handle it gently.

I think that when `formatStackTraceAsArray` is enabled, the `StackTrace` and `RemoteStackTrace` Exception properties, when `null`, should be formatted as empty arrays.
