### PR TITLE
Change default TypeName to '_doc'

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -278,7 +278,7 @@ namespace Serilog.Sinks.Elasticsearch
         /// The default Elasticsearch type name used for Elasticsearch versions prior to 7.
         /// <para>As of <c>Elasticsearch 7</c> and up <c>_type</c> has been removed.</para>
         /// </summary>
-        public static string DefaultTypeName { get; } = "logevent";
+        public static string DefaultTypeName { get; } = "_doc";
 
         /// <summary>
         /// Instructs the sink to auto detect the running Elasticsearch version.

--- a/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTestsBase.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTestsBase.cs
@@ -73,7 +73,7 @@ namespace Serilog.Sinks.Elasticsearch.Tests
                 }
                 action.IndexAction.Should().NotBeNull();
                 action.IndexAction.Index.Should().NotBeNullOrEmpty().And.StartWith("logstash-");
-                action.IndexAction.Type.Should().NotBeNullOrEmpty().And.Be("logevent");
+                action.IndexAction.Type.Should().NotBeNullOrEmpty().And.Be("_doc");
 
                 SerilogElasticsearchEvent actionMetaData;
                 try


### PR DESCRIPTION
Fixes #200

It introduces a potential "breaking change", since it influences code relying on the former default `TypeName`.