### PR TITLE
Upgrade Elasticsearch.Net to 7.8.1 

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -47,12 +47,12 @@
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
-    <PackageReference Include="Elasticsearch.Net" Version="7.0.0" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.8.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />
   </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+        <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     </ItemGroup>
 
 </Project>

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Bootstrap/ClientTestClusterBase.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Bootstrap/ClientTestClusterBase.cs
@@ -1,7 +1,7 @@
-﻿using Elastic.Managed.Ephemeral;
-using Elastic.Managed.Ephemeral.Plugins;
-using Elastic.Xunit;
-using Nest;
+﻿using Elastic.Elasticsearch.Ephemeral;
+using Elastic.Elasticsearch.Ephemeral.Plugins;
+using Elastic.Elasticsearch.Xunit;
+using Elastic.Stack.ArtifactsApi.Products;
 
 namespace Serilog.Sinks.Elasticsearch.IntegrationTests.Bootstrap
 {

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Bootstrap/SerilogSinkElasticsearchXunitRunOptions.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Bootstrap/SerilogSinkElasticsearchXunitRunOptions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
-using Elastic.Xunit;
+using Elastic.Elasticsearch.Xunit;
 
 namespace Serilog.Sinks.Elasticsearch.IntegrationTests.Bootstrap
 {

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Bootstrap/XunitBootstrap.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Bootstrap/XunitBootstrap.cs
@@ -1,6 +1,6 @@
-﻿using Elastic.Xunit;
+﻿using Elastic.Elasticsearch.Xunit;
 using Serilog.Sinks.Elasticsearch.IntegrationTests.Bootstrap;
 using Xunit;
 
-[assembly: TestFramework("Elastic.Xunit.Sdk.ElasticTestFramework", "Elastic.Xunit")]
+[assembly: TestFramework("Elastic.Elasticsearch.Xunit.Sdk.ElasticTestFramework", "Elastic.Elasticsearch.Xunit")]
 [assembly: ElasticXunitConfiguration(typeof(SerilogSinkElasticsearchXunitRunOptions))]

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch6/Bootstrap/Elasticsearch6XTestBase.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch6/Bootstrap/Elasticsearch6XTestBase.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Security.Cryptography.X509Certificates;
-using Elastic.Managed.Ephemeral;
-using Elastic.Xunit;
-using Elastic.Xunit.XunitPlumbing;
+using Elastic.Elasticsearch.Ephemeral;
+using Elastic.Elasticsearch.Xunit;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Elasticsearch.Net6;
 using Nest6;
 using Serilog.Sinks.Elasticsearch.IntegrationTests.Bootstrap;

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch6/Elasticsearch6X.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch6/Elasticsearch6X.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using Elastic.Xunit.XunitPlumbing;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Serilog.Sinks.Elasticsearch.IntegrationTests.Bootstrap;
 using Serilog.Sinks.Elasticsearch.IntegrationTests.Elasticsearch6.Bootstrap;

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch6/Elasticsearch6XUsing7X.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch6/Elasticsearch6XUsing7X.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using Elastic.Xunit.XunitPlumbing;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Serilog.Sinks.Elasticsearch.IntegrationTests.Bootstrap;
 using Serilog.Sinks.Elasticsearch.IntegrationTests.Elasticsearch6.Bootstrap;

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch7/Bootstrap/Elasticsearch7XCluster.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch7/Bootstrap/Elasticsearch7XCluster.cs
@@ -8,7 +8,7 @@ namespace Serilog.Sinks.Elasticsearch.IntegrationTests.Elasticsearch7.Bootstrap
 
 		private static ClientTestClusterConfiguration CreateConfiguration()
 		{
-			return new ClientTestClusterConfiguration("7.0.0")
+			return new ClientTestClusterConfiguration("7.8.0")
 			{
 				MaxConcurrency = 1
 			};

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch7/Bootstrap/Elasticsearch7XTestBase.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch7/Bootstrap/Elasticsearch7XTestBase.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Security.Cryptography.X509Certificates;
-using Elastic.Managed.Ephemeral;
-using Elastic.Xunit;
-using Elastic.Xunit.XunitPlumbing;
+using Elastic.Elasticsearch.Ephemeral;
+using Elastic.Elasticsearch.Xunit;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using Nest;
 using Serilog.Sinks.Elasticsearch.IntegrationTests.Bootstrap;

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch7/Elasticsearch7X.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch7/Elasticsearch7X.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using Elastic.Xunit.XunitPlumbing;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Serilog.Sinks.Elasticsearch.IntegrationTests.Bootstrap;
 using Serilog.Sinks.Elasticsearch.IntegrationTests.Elasticsearch7.Bootstrap;

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch7/Elasticsearch7XUsing6X.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch7/Elasticsearch7XUsing6X.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using Elastic.Xunit.XunitPlumbing;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Serilog.Sinks.Elasticsearch.IntegrationTests.Bootstrap;
 using Serilog.Sinks.Elasticsearch.IntegrationTests.Elasticsearch7.Bootstrap;

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Serilog.Sinks.Elasticsearch.IntegrationTests.csproj
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Serilog.Sinks.Elasticsearch.IntegrationTests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190708T081758" />
-    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20190708T081758" />
+    <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.2.4" />
+    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.2.4" />
     <PackageReference Include="FluentAssertions" Version="5.7.0" />
     <PackageReference Include="NEST" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Serilog.Sinks.Elasticsearch.IntegrationTests.csproj
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Serilog.Sinks.Elasticsearch.IntegrationTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.2.4" />
     <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.2.4" />
     <PackageReference Include="FluentAssertions" Version="5.7.0" />
-    <PackageReference Include="NEST" Version="7.0.0" />
+    <PackageReference Include="NEST" Version="7.8.1" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
   </ItemGroup>
 </Project>

--- a/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/Serilog.Sinks.Elasticsearch.Tests.csproj
@@ -51,15 +51,15 @@
 
   <ItemGroup>
     <DotNetCliToolReference Include="dotnet-version" Version="1.1.2" />
-      
+
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1" />
     <PackageReference Include="dotnet-test-nunit" Version="3.4.0-beta-3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Elasticsearch.Net" Version="7.0.0" />
-    <PackageReference Include="NEST" Version="7.0.0" />
-    <PackageReference Include="NEST.JsonNetSerializer" Version="7.0.0" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.8.1" />
+    <PackageReference Include="NEST" Version="7.8.1" />
+    <PackageReference Include="NEST.JsonNetSerializer" Version="7.8.1" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.2" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
   </ItemGroup>
@@ -77,7 +77,7 @@
 
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-        <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+        <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">


### PR DESCRIPTION
**What issue does this PR address?**

Issue #340.

**Does this PR introduce a breaking change?**

None in Serilog.Sinks.Elasticsearch.

There were a few breaking changes in Elasticsearch.Net between v7.0.0–v7.8.1 but the sink is not affected by them as far as I could tell and test.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:

I had to introduce two extra changes for the upgrade:

1. Upgrade `Microsoft.CSharp` v4.5.0 → v4.6.0 because it was upgraded in Elasticsearch.Net as well.
1. Replace `Elastic.Managed` and `Elastic.Xunit` packages in the integration tests with the newer `Elastic.Elasticsearch.Managed` and `Elastic.Elasticsearch.Xunit`. The old packages were deleted from the Elastic Abstractions CI feed and not available anymore.

I ran the existing unit and integration tests (ES v6.0 and v7.8) on net461 (mono 6.10.0) and netcoreapp 2.1. I was not able to test on Windows since I don't have one atm. Hopefully, they will pass in CI on Windows 🙏 