### PR TITLE
Issue nr: 14594 - removing old implementation where fields where dot-…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+* Disable dot-escaping for field names, because ELK already supports dots in field names.
+
 8.2
  * Allow the use of templateCustomSettings when reading from settings json (#315)
  * Updated Elasticsearch.Net dependency #340


### PR DESCRIPTION
…escaped due to old ELK not supporting it. But now this is supported, therefore there is no need to escape it anylonger.

**What issue does this PR address?**

Disable dot escaping for field names, as it is supported since long time ago in ELK.


**Does this PR introduce a breaking change?**

If the field name `x.y` was used, till now in kibana it would show as `x/y`, after this commit, it will show as `x.y`. But I think the breaking change is very small.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features)

There was no need for new unit tests, since only old code was removed.

**Other information**:

Also changed a method from using recursion to a simple while loop.