### PR TITLE
Added support for controlling the op_type when indexing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,23 @@
 ## Changelog
 
 * Disable dot-escaping for field names, because ELK already supports dots in field names.
+* Support for explicitly setting `Options.TypeName` to `null` this will remove the 
+  deprecated `_type` from the bulk payload being sent to Elastic. Earlier an exception was
+  thrown if the `Options.TypeName` was `null`. _If you're using `AutoRegisterTemplateVersion.ESv7`
+  we'll not force the type to `_doc` if it's set to `null`. This is a small step towards support 
+  for writing logs to Elastic v8. #345
+* Support for setting the Elastic `op_type` e.g. `index` or `create` for bulk actions.
+  This is a requirement for writing to [data streams](https://www.elastic.co/guide/en/elasticsearch/reference/7.9/data-streams.html)
+  that's only supporting `create`. Data streams is a more slipped stream way to handle rolling
+  indices, that previous required an ILM, template and a magic write alias. Now it's more integrated
+  in Elasticsearch and Kibana. If you're running Elastic `7.9` you'll get rolling indices out of the box
+  with this configuration:
+  ```
+  TypeName = null,
+  IndexFormat = "logs-my-stream",
+  BatchAction = ElasticOpType.Create,
+  ```
+  _Note: that current templates doesn't support data streams._ #355
 
 8.2
  * Allow the use of templateCustomSettings when reading from settings json (#315)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This example shows the options that are currently available when using the appSe
     <add key="serilog:write-to:Elasticsearch.typeName" value="myCustomLogEventType"/>
     <add key="serilog:write-to:Elasticsearch.pipelineName" value="myCustomPipelineName"/>
     <add key="serilog:write-to:Elasticsearch.batchPostingLimit" value="50"/>
+    <add key="serilog:write-to:Elasticsearch.batchAction" value="create"/>
     <add key="serilog:write-to:Elasticsearch.period" value="2"/>
     <add key="serilog:write-to:Elasticsearch.inlineFields" value="true"/>
     <add key="serilog:write-to:Elasticsearch.restrictedToMinimumLevel" value="Warning"/>
@@ -179,6 +180,7 @@ In your `appsettings.json` file, under the `Serilog` node, :
           "typeName": "myCustomLogEventType",
           "pipelineName": "myCustomPipelineName",
           "batchPostingLimit": 50,
+          "batchAction": "create",
           "period": 2,
           "inlineFields": true,
           "restrictedToMinimumLevel": "Warning",

--- a/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/LoggerConfigurationElasticSearchExtensions.cs
@@ -143,6 +143,7 @@ namespace Serilog
         /// <param name="failureSink">Sink to use when Elasticsearch is unable to accept the events. This is optionally and depends on the EmitEventFailure setting.</param>   
         /// <param name="singleEventSizePostingLimit"><see cref="ElasticsearchSinkOptions.SingleEventSizePostingLimit"/>The maximum length of an event allowed to be posted to Elasticsearch.default null</param>
         /// <param name="templateCustomSettings">Add custom elasticsearch settings to the template</param>
+        /// <param name="batchAction">Configures the OpType being used when inserting document in batch. Must be set to create for data streams.</param>
         /// <returns>LoggerConfiguration object</returns>
         /// <exception cref="ArgumentNullException"><paramref name="nodeUris"/> is <see langword="null" />.</exception>
         public static LoggerConfiguration Elasticsearch(
@@ -180,7 +181,8 @@ namespace Serilog
             ILogEventSink failureSink = null,
             long? singleEventSizePostingLimit = null,
             int? bufferFileCountLimit = null,
-            Dictionary<string,string> templateCustomSettings = null)
+            Dictionary<string,string> templateCustomSettings = null,
+            ElasticOpType batchAction = ElasticOpType.Index)
         {
             if (string.IsNullOrEmpty(nodeUris))
                 throw new ArgumentNullException(nameof(nodeUris), "No Elasticsearch node(s) specified.");
@@ -208,6 +210,7 @@ namespace Serilog
             }
 
             options.BatchPostingLimit = batchPostingLimit;
+            options.BatchAction = batchAction;
             options.SingleEventSizePostingLimit = singleEventSizePostingLimit;
             options.Period = TimeSpan.FromSeconds(period);
             options.InlineFields = inlineFields;

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/DurableElasticsearchSink.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/DurableElasticsearchSink.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Elasticsearch.Net;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -55,15 +54,16 @@ namespace Serilog.Sinks.Elasticsearch.Durable
 
             
             var elasticSearchLogClient = new ElasticsearchLogClient(
-                 elasticLowLevelClient: _state.Client, 
-                cleanPayload: _state.Options.BufferCleanPayload);
+                elasticLowLevelClient: _state.Client, 
+                cleanPayload: _state.Options.BufferCleanPayload,
+                elasticOpType: _state.Options.BatchAction);
 
             var payloadReader = new ElasticsearchPayloadReader(
                  pipelineName: _state.Options.PipelineName,  
                  typeName:_state.Options.TypeName, 
                  serialize:_state.Serialize,  
-                 getIndexForEvent: _state.GetBufferedIndexForEvent
-                );
+                 getIndexForEvent: _state.GetBufferedIndexForEvent,
+                 elasticOpType: _state.Options.BatchAction);
 
             _shipper = new ElasticsearchLogShipper(
                 bufferBaseFilename: _state.Options.BufferBaseFilename,

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchLogClient.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/Durable/Elasticsearch/ElasticsearchLogClient.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.ExceptionServices;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Elasticsearch.Net;
 using Serilog.Debugging;
@@ -17,17 +14,21 @@ namespace Serilog.Sinks.Elasticsearch.Durable
     {
         private readonly IElasticLowLevelClient _elasticLowLevelClient;
         private readonly Func<string, long?, string, string> _cleanPayload;
+        private readonly ElasticOpType _elasticOpType;
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="elasticLowLevelClient"></param>
         /// <param name="cleanPayload"></param>
+        /// <param name="elasticOpType"></param>
         public ElasticsearchLogClient(IElasticLowLevelClient elasticLowLevelClient,
-            Func<string, long?, string, string> cleanPayload)
+            Func<string, long?, string, string> cleanPayload,
+            ElasticOpType elasticOpType)
         {
             _elasticLowLevelClient = elasticLowLevelClient;
             _cleanPayload = cleanPayload;
+            _elasticOpType = elasticOpType;
         }
 
         public async Task<SentPayloadResult> SendPayloadAsync(List<string> payload)
@@ -85,7 +86,7 @@ namespace Serilog.Sinks.Elasticsearch.Durable
             bool hasErrors = false;
             foreach (dynamic item in items)
             {
-                var itemIndex = item?["index"];
+                var itemIndex = item?[ElasticsearchSink.BulkAction(_elasticOpType)];
                 long? status = itemIndex?["status"];
                 i++;
                 if (!status.HasValue || status < 300)

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using Elasticsearch.Net;
 using Serilog.Core;
 using Serilog.Events;
@@ -112,6 +113,12 @@ namespace Serilog.Sinks.Elasticsearch
         /// The default elasticsearch type name to use for the log events. Defaults to: logevent.
         /// </summary>
         public string TypeName { get; set; }
+
+        /// <summary>
+        /// Configures the <see cref="OpType"/> being used when bulk indexing documents.
+        /// In order to use data streams, this needs to be set to OpType.Create. 
+        /// </summary>
+        public ElasticOpType BatchAction { get; set; } = ElasticOpType.Index;
 
         /// <summary>
         /// Function to decide which Pipeline to use for the LogEvent
@@ -402,5 +409,26 @@ namespace Serilog.Sinks.Elasticsearch
         /// When the template cannot be registered, throw an exception and fail the sink.
         /// </summary>
         FailSink = 8
+    }
+
+    /// <summary>
+    /// Collection of op_type:s that can be used when indexing documents
+    /// ‹https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html
+    ///
+    /// This is the same as the internal <seealso cref="OpType"/> but we don't want to
+    /// expose it in the API.
+    /// </summary>
+    public enum ElasticOpType
+    {
+        /// <summary>
+        /// Default option, creates or updates a document.
+        /// </summary>
+        [EnumMember(Value = "index")] Index,
+        /// <summary>
+        /// Set to create to only index the document if it does not already exist (put if absent).
+        /// - If a document with the specified _id already exists, the indexing operation will fail.
+        /// - If the request targets a data stream, an op_type of create is required
+        /// </summary>
+        [EnumMember(Value = "create")] Create
     }
 }

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
@@ -74,10 +74,6 @@ namespace Serilog.Sinks.Elasticsearch
             {
                 options.TypeName = "_doc";
             }
-            else
-            {
-                if (string.IsNullOrWhiteSpace(options.TypeName)) throw new ArgumentException("options.TypeName");
-            }
 
             _templateName = options.TemplateName;
             _templateMatchString = IndexFormatRegex.Replace(options.IndexFormat, @"$1*$2");

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
@@ -69,8 +69,8 @@ namespace Serilog.Sinks.Elasticsearch
             if (string.IsNullOrWhiteSpace(options.IndexFormat)) throw new ArgumentException("options.IndexFormat");
             if (string.IsNullOrWhiteSpace(options.TemplateName)) throw new ArgumentException("options.TemplateName");
 
-            // Strip type argument if ESv7 since multiple types are not supported anymore
-            if (options.AutoRegisterTemplateVersion == AutoRegisterTemplateVersion.ESv7)
+            // Since TypeName is deprecated we shouldn't set it, if has been deliberately set to null.
+            if (options.TypeName == null && options.AutoRegisterTemplateVersion == AutoRegisterTemplateVersion.ESv7)
             {
                 options.TypeName = "_doc";
             }

--- a/test/Serilog.Sinks.Elasticsearch.Tests/BulkActionTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/BulkActionTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Serilog.Events;
+using Serilog.Parsing;
+using Xunit;
+
+namespace Serilog.Sinks.Elasticsearch.Tests
+{
+    public class BulkActionTests : ElasticsearchSinkTestsBase
+    {
+        [Fact]
+        public void DefaultBulkActionV7()
+        {
+            _options.IndexFormat = "logs";
+            _options.TypeName = "_doc";
+            _options.PipelineName = null;
+            using (var sink = new ElasticsearchSink(_options))
+            {
+                sink.Emit(ADummyLogEvent());
+                sink.Emit(ADummyLogEvent());
+            }
+
+            var bulkJsonPieces = this.AssertSeenHttpPosts(_seenHttpPosts, 2, 1);
+            const string expectedAction = @"{""index"":{""_type"":""_doc"",""_index"":""logs""}}";
+            bulkJsonPieces[0].Should().Be(expectedAction);
+        }
+        
+        [Fact]
+        public void DefaultBulkActionV8()
+        {
+            _options.IndexFormat = "logs";
+            _options.TypeName = null;
+            _options.PipelineName = null;
+            using (var sink = new ElasticsearchSink(_options))
+            {
+                sink.Emit(ADummyLogEvent());
+                sink.Emit(ADummyLogEvent());
+            }
+
+            var bulkJsonPieces = this.AssertSeenHttpPosts(_seenHttpPosts, 2, 1);
+            const string expectedAction = @"{""index"":{""_index"":""logs""}}";
+            bulkJsonPieces[0].Should().Be(expectedAction);
+        }
+        
+        [Fact]
+        public void BulkActionDataStreams()
+        {
+            _options.IndexFormat = "logs-my-stream";
+            _options.TypeName = null;
+            _options.PipelineName = null;
+            _options.BatchAction = ElasticOpType.Create;
+            
+            using (var sink = new ElasticsearchSink(_options))
+            {
+                sink.Emit(ADummyLogEvent());
+                sink.Emit(ADummyLogEvent());
+            }
+
+            var bulkJsonPieces = this.AssertSeenHttpPosts(_seenHttpPosts, 2, 1);
+            const string expectedAction = @"{""create"":{""_index"":""logs-my-stream""}}";
+            bulkJsonPieces[0].Should().Be(expectedAction);
+        }
+        
+        [Fact]
+        public void PipelineAction()
+        {
+            _options.IndexFormat = "logs-my-stream";
+            _options.TypeName = "_doc";
+            _options.PipelineName = "my-pipeline";
+            _options.BatchAction = ElasticOpType.Index;
+            
+            using (var sink = new ElasticsearchSink(_options))
+            {
+                sink.Emit(ADummyLogEvent());
+                sink.Emit(ADummyLogEvent());
+            }
+
+            var bulkJsonPieces = this.AssertSeenHttpPosts(_seenHttpPosts, 2, 1);
+            const string expectedAction = @"{""index"":{""_type"":""_doc"",""_index"":""logs-my-stream"",""pipeline"":""my-pipeline""}}";
+            bulkJsonPieces[0].Should().Be(expectedAction);
+        }
+
+        private static LogEvent ADummyLogEvent() {
+            return new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
+                new MessageTemplate("A template", Enumerable.Empty<MessageTemplateToken>()),
+                Enumerable.Empty<LogEventProperty>());
+        }
+    }
+}

--- a/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTestsBase.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/ElasticsearchSinkTestsBase.cs
@@ -102,9 +102,9 @@ namespace Serilog.Sinks.Elasticsearch.Tests
             throw new Exception("boom!");
         }
 
-        protected string[] AssertSeenHttpPosts(List<string> _seenHttpPosts, int lastN)
+        protected string[] AssertSeenHttpPosts(List<string> _seenHttpPosts, int lastN, int expectedNumberOfRequests = 2)
         {
-            _seenHttpPosts.Should().NotBeEmpty().And.HaveCount(2);
+            _seenHttpPosts.Should().NotBeEmpty().And.HaveCount(expectedNumberOfRequests);
             var json = string.Join("", _seenHttpPosts);
             var bulkJsonPieces = json.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
 


### PR DESCRIPTION
In order to write to data streams we'll need to set the
`op_type` to `create` the default is `index`

In order to don't serialize null values for the batch action and to not depend
on custom serialization setting we're using `LowLevelRequestResponseSerializer.Instance`
for serialization of the action.

We won't throw exception when setting the TypeName to null since:
- This is deprecated in v7
- Won't work in v8

**What issue does this PR address?**
- #355 It's possible to set the op_type to create by setting `BatchAction` to `ElasticOpType.Create`
- #345 It's possible to set `TypeName` to `null` to remove it from the payload being sent to Elastic.

**Does this PR introduce a breaking change?**
I don't think we have introduced an breaking change but we'll need to review the following changes to make sure they're not breaking.

- The custom serializer for the action has been replaced by a specific one, it's not impossible that someone has been intercepting this call for adding custom elements when logging.
https://github.com/serilog/serilog-sinks-elasticsearch/pull/356/files#diff-15ec7bbc1a4d48125fae012ffb1896acR191

- Earlier and exception was thrown when trying to set the `TypeName` to `null` it's unlikely that someone has relied on this exception. https://github.com/serilog/serilog-sinks-elasticsearch/pull/356/files#diff-cb61ceb2dfe8091b1abe76e3c275d6d0L77

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)

**Other information**:
