### PR TITLE
Fix HasProperty when settings is a Dictionary

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticSearchSink.cs
@@ -156,7 +156,7 @@ namespace Serilog.Sinks.Elasticsearch
         // Helper function: checks if a given dynamic member / dictionary key exists at runtime
         private static bool HasProperty(dynamic settings, string name)
         {
-            if (settings is System.Dynamic.ExpandoObject)
+            if (settings is IDictionary<string, object>)
                 return ((IDictionary<string, object>)settings).ContainsKey(name);
 
             if (settings is System.Dynamic.DynamicObject)


### PR DESCRIPTION
**What issue does this PR address?**
#357

**Does this PR introduce a breaking change?**
No, ExpandoObject is already an IDictionary<string, object> 
