### PR TITLE
Override type name if specified

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make sure TypeName is set to `_doc` when setting the template version to `ESv7`.
+   The regression was introduced in `8.4.0`. #364
 
 ## [8.4.0] - 2020-09-19
 ### Added

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
@@ -70,7 +70,7 @@ namespace Serilog.Sinks.Elasticsearch
             if (string.IsNullOrWhiteSpace(options.TemplateName)) throw new ArgumentException("options.TemplateName");
 
             // Since TypeName is deprecated we shouldn't set it, if has been deliberately set to null.
-            if (options.TypeName == null && options.AutoRegisterTemplateVersion == AutoRegisterTemplateVersion.ESv7)
+            if (options.TypeName != null && options.AutoRegisterTemplateVersion == AutoRegisterTemplateVersion.ESv7)
             {
                 options.TypeName = "_doc";
             }

--- a/test/Serilog.Sinks.Elasticsearch.Tests/BulkActionTests.cs
+++ b/test/Serilog.Sinks.Elasticsearch.Tests/BulkActionTests.cs
@@ -25,6 +25,24 @@ namespace Serilog.Sinks.Elasticsearch.Tests
             const string expectedAction = @"{""index"":{""_type"":""_doc"",""_index"":""logs""}}";
             bulkJsonPieces[0].Should().Be(expectedAction);
         }
+
+        [Fact]
+        public void BulkActionV7OverrideTypeName()
+        {
+            _options.IndexFormat = "logs";
+            _options.TypeName = "logevent"; // This is the default value when creating the sink via configuration
+            _options.AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv7;
+            _options.PipelineName = null;
+            using (var sink = new ElasticsearchSink(_options))
+            {
+                sink.Emit(ADummyLogEvent());
+                sink.Emit(ADummyLogEvent());
+            }
+
+            var bulkJsonPieces = this.AssertSeenHttpPosts(_seenHttpPosts, 2, 1);
+            const string expectedAction = @"{""index"":{""_type"":""_doc"",""_index"":""logs""}}";
+            bulkJsonPieces[0].Should().Be(expectedAction);
+        }        
         
         [Fact]
         public void DefaultBulkActionV8()


### PR DESCRIPTION
Fixes a regression introduced in #356
We should override the TypeName if it's specified.

Note that there are different defaults depending
on how the options are created.
- Created from configuration it defaults to `logevent`
- Created from code it defaults to `_doc`

**What issue does this PR address?**
#364

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [x] Unit Tests for the changes have been added (for bug fixes / features)
