### PR TITLE
fix: Correct comment about default TypeName

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -110,7 +110,7 @@ namespace Serilog.Sinks.Elasticsearch
         public string DeadLetterIndexName { get; set; }
 
         ///<summary>
-        /// The default elasticsearch type name to use for the log events. Defaults to: logevent.
+        /// The default elasticsearch type name to use for the log events. Defaults to: "_doc".
         /// </summary>
         public string TypeName { get; set; }
 


### PR DESCRIPTION
The default TypeName was changed to '_doc' in #298

**What issue does this PR address?**
Correcting a documentation error.

**Does this PR introduce a breaking change?**
No. It does not affect the running code.

**Please check if the PR fulfills these requirements**
- [X] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [X] Unit Tests for the changes have been added (for bug fixes / features)


**Other information**:
None
