### PR TITLE
Use apikey to access elastic search

### DIFF
--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -282,7 +282,11 @@ namespace Serilog.Sinks.Elasticsearch
         public RollingInterval BufferFileRollingInterval { get; set; }
 
         /// <summary>
-        /// Apikey to access elasticsearch, the value is encoded, atob(`id:apikey`).This is another method instead user/password
+        /// Apikey to access elasticsearch, the value is encoded
+        /// If your elasticsearch can be accessed using user and password, you access via url like this: http://user:password@localhost
+        /// For another choice, you can using a apiKey, which can be created in kibana:    POST /security/api_key { "name": "aaa-apikeys", "role_descriptors": { "abc-shared-application": { "cluster": [ "all" ], "index": [ { "names": [ "abc_share*" ], "privileges": [ "all" ] } ] } } }
+        /// then you can get the apikey coded by base64 it like this: aFlBbDVvY0JOblduWHdpZnNLOUk6cEt2Y01tYVlRQ3FsWlF0MVVjRkN034==
+        /// For more detail about apiKey, see: https://www.elastic.co/guide/en/apm/server/7.15/api-key.html
         /// </summary>
         public string Apikey { get; set; }
 

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkOptions.cs
@@ -282,6 +282,11 @@ namespace Serilog.Sinks.Elasticsearch
         public RollingInterval BufferFileRollingInterval { get; set; }
 
         /// <summary>
+        /// Apikey to access elasticsearch, the value is encoded, atob(`id:apikey`).This is another method instead user/password
+        /// </summary>
+        public string Apikey { get; set; }
+
+        /// <summary>
         /// Configures the elasticsearch sink defaults
         /// </summary>
         public ElasticsearchSinkOptions()

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ElasticsearchSinkState.cs
@@ -86,6 +86,9 @@ namespace Serilog.Sinks.Elasticsearch
             if (options.ModifyConnectionSettings != null)
                 configuration = options.ModifyConnectionSettings(configuration);
 
+            if (!string.IsNullOrEmpty(options.Apikey))
+                configuration = configuration.ApiKeyAuthentication(new ApiKeyAuthenticationCredentials(options.Apikey));
+
             configuration.ThrowExceptions();
 
             _client = new ElasticLowLevelClient(configuration);

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch6/Elasticsearch6XUsing7X.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch6/Elasticsearch6XUsing7X.cs
@@ -54,6 +54,7 @@ namespace Serilog.Sinks.Elasticsearch.IntegrationTests.Elasticsearch6
                             o.DetectElasticsearchVersion = true;
                             o.AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv7;
                             o.AutoRegisterTemplate = true;
+                            o.ApiKey = "aWQ6d3d3ZGRkZGRkZGRkZA==";
                         })
                     );
                 var logger = loggerConfig.CreateLogger();

--- a/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch7/Elasticsearch7XUsing6X.cs
+++ b/test/Serilog.Sinks.Elasticsearch.IntegrationTests/Elasticsearch7/Elasticsearch7XUsing6X.cs
@@ -51,6 +51,7 @@ namespace Serilog.Sinks.Elasticsearch.IntegrationTests.Elasticsearch7
                             o.DetectElasticsearchVersion = true;
                             o.AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv6;
                             o.AutoRegisterTemplate = true;
+                            o.ApiKey = "aWQ6d3d3ZGRkZGRkZGRkZA==";
                         })
                     );
                 using (var logger = loggerConfig.CreateLogger())


### PR DESCRIPTION
Add a property (Apikey) in Update ElasticsearchSinkOptions.cs. 

You can assign it some vaule.
Then you can access your elasticsearch using the apikey, instead user/password.

In some cases, api key is a more appropriate choice.

You can create the api key, in kibana: 
`POST /security/api_key
{
    "name": "aaa-apikeys",
    "role_descriptors": {
        "abc-shared-application": {
            "cluster": [
                "all"
            ],
            "index": [
                {
                    "names": [
                        "abc_share*"
                    ],
                    "privileges": [
                        "all"
                    ]
                }
            ]
        }
    }
}`

then you can get the apikey coded by base64 
it like this:
`aFlBbDVvY0JOblduWHdpZnNLOUk6cEt2Y01tYVlRQ3FsWlF0MVVjRkN034==`

For more detail about apiKey, see:  https://www.elastic.co/guide/en/apm/server/7.15/api-key.html
