### PR TITLE
Add Sink configure option to effectively disable SSL Certificate Verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ In your `appsettings.json` file, under the `Serilog` node, :
           "connectionPool": "My.Namespace.MyConnectionPool, My.Assembly.Name",
           "customFormatter": "My.Namespace.MyCustomFormatter, My.Assembly.Name",
           "customDurableFormatter": "My.Namespace.MyCustomDurableFormatter, My.Assembly.Name",
-          "failureSink": "My.Namespace.MyFailureSink, My.Assembly.Name"
+          "failureSink": "My.Namespace.MyFailureSink, My.Assembly.Name",
+          "ignoreServerCertificateValidation": "false"
         }
     }]
   }

--- a/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ModifyConnectionSettingsOptions.cs
+++ b/src/Serilog.Sinks.Elasticsearch/Sinks/ElasticSearch/ModifyConnectionSettingsOptions.cs
@@ -1,0 +1,12 @@
+namespace Serilog.Sinks.Elasticsearch.Sinks.ElasticSearch;
+
+public class ModifyConnectionSettingsOptions
+{
+    public string ConnectionGlobalHeaders { get; set; }
+    
+    public bool IgnoreSslRemoteCertificateChainErrors { get; set; }
+    
+    public bool IgnoreSslRemoteCertificateNameMismatchErrors { get; set; }
+    
+    public bool IgnoreSslRemoteCertificateNotAvailableErrors { get; set; }
+}


### PR DESCRIPTION
Add the 'ignoreServerCertificateValidation' Sink configuration parameter to LoggerConfigurationElasticSearchExtensions.cs which, when true will configure the Elasticsearch client with a ServerCertificateValidationCallback which always returns true.

The default behaviour is unchanged.

**What issue does this PR address?**
#384 

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] Unit Tests for the changes have been added (for bug fixes / features) - Could not find a sensible place to put tests, grateful for direction if tests are required for this change.

**Other information**:
