### PR TITLE
Update to `Serilog.Sinks.PeriodicBatching` v4.0 and break dependency on deprecated inheritance API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains two nuget packages: `Serilog.Sinks.Elasticsearch` and `Serilog.Formatting.Elasticsearch`.
 
-> __Just a heads up that the .NET team @elastic have created their own new Serilog Sink called Elastic.Serilog.Sinks (Package: https://www.nuget.org/packages/Elastic.Serilog.Sinks#readme-body-tab and documentation: https://www.elastic.co/guide/en/ecs-logging/dotnet/current/serilog-data-shipper.html). Althought this current sink will still work, I advice you to have a look first at the official Elastic implementation as it is better supported and more up to date.__
+> __Just a heads up that the .NET team @elastic have created their own new Serilog Sink called Elastic.Serilog.Sinks (Package: https://www.nuget.org/packages/Elastic.Serilog.Sinks#readme-body-tab and documentation: https://www.elastic.co/guide/en/ecs-logging/dotnet/current/serilog-data-shipper.html). Although this current sink will still work, I advise you to have a look first at the official Elastic implementation as it is better supported and more up to date.__
 
 ## Table of contents
 

--- a/sample/Serilog.Sinks.Elasticsearch.Sample/Serilog.Sinks.Elasticsearch.Sample.csproj
+++ b/sample/Serilog.Sinks.Elasticsearch.Sample/Serilog.Sinks.Elasticsearch.Sample.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
 

--- a/serilog-sinks-elasticsearch.sln
+++ b/serilog-sinks-elasticsearch.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Files", "Files", "{148431F6
 		LICENSE = LICENSE
 		nuget.config = nuget.config
 		README.md = README.md
+		GitVersion.yml = GitVersion.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.Elasticsearch", "src\Serilog.Sinks.Elasticsearch\Serilog.Sinks.Elasticsearch.csproj", "{EEB0D119-687E-444E-BF14-9BDAEC9BA3EF}"

--- a/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
+++ b/src/Serilog.Sinks.Elasticsearch/Serilog.Sinks.Elasticsearch.csproj
@@ -4,9 +4,7 @@
     <Title>Serilog.Sinks.Elasticsearch</Title>
     <Description>Serilog sink for Elasticsearch</Description>
     <Copyright>Copyright © Serilog Contributors 2023</Copyright>
-  </PropertyGroup>
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -22,6 +20,8 @@
     <RepositoryUrl>https://github.com/serilog-contrib/serilog-sinks-elasticsearch</RepositoryUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
+    <RootNamespace>Serilog</RootNamespace>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
@@ -29,27 +29,26 @@
     <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <NoWarn>1591;1701;1702</NoWarn>
+    <DefineConstants>$(DefineConstants);DURABLE;THREADING_TIMER;ASYNC_DISPOSABLE</DefineConstants>
+  </PropertyGroup>
   
   <ItemGroup>
-
     <ProjectReference Include="..\Serilog.Formatting.Elasticsearch\Serilog.Formatting.Elasticsearch.csproj" />
       
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.0" />
     <PackageReference Include="Elasticsearch.Net" Version="7.17.5" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <_Parameter1>Serilog.Sinks.Elasticsearch.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b81894191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066b19485ec</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
+    <InternalsVisibleTo Include="Serilog.Sinks.Elasticsearch.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c6fe0fe83ef33c1080bf30690765bc6eb0df26ebfdf8f21670c64265b30db09f73a0dea5b3db4c9d18dbf6d5a25af5ce9016f281014d79dc3b4201ac646c451830fc7e61a2dfd633d34c39f87b81894191652df5ac63cc40c77f3542f702bda692e6e8a9158353df189007a49da0f3cfd55eb250066b19485ec" />
 
-  <ItemGroup>
     <None Include="..\..\assets\serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="" />
+
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
**What issue does this PR address?**

Inheriting from `PeriodicBatchingSink` has been deprecated for a few versions, and with v4 of that sink is no longer supported.

**Does this PR introduce a breaking change?**

Yes, it's no longer possible to cast `ElasticsearchSink` to `PeriodicBatchingSink`. The forced major version upgrades for `Serilog.Sinks.PeriodicBatching` and `Serilog` also constitute a major-version-bump-worthy change.

Practically, no - `ElasticsearchSink` still supports `ILogEventSink` and `IDisposable` as it did before.

**Please check if the PR fulfills these requirements**
- [x] The commit follows our [guidelines](https://github.com/serilog/serilog/blob/dev/CONTRIBUTING.md)
- [ ] ~~Unit Tests for the changes have been added (for bug fixes / features)~~ N/A

**Other information**:

The newer `PeriodicBatchingSink` implementation supports `IAsyncDisposable`, and in doing so avoids a rare but theoretically-possible shutdown hang. I've added a `net6.0` target and implemented forwarding of `IAsyncDisposable.DisposeAsync()` to the internal wrapped sink to make this accessible. Happy to back this out if it conflicts with other goals/intentions here.

See also https://github.com/serilog/serilog-sinks-periodicbatching/issues/69